### PR TITLE
Added a possibility to run tests that use 'upload' test-helper in Microsoft browsers

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -4,7 +4,7 @@ import { assert } from '@ember/debug';
 export async function upload(selector, file) {
   let input = find(selector);
   assert(`Selector '${selector}' is not input element.`, input.tagName === 'INPUT');
-  assert(`File must be instance of File type`, file instanceof File);
+  assert(`File must be instance of File type`, file instanceof File || file instanceof Blob);
 
   // This hack is here since we can't mock out the
   // FileList API easily; we're taking advantage

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -4,7 +4,7 @@ import { assert } from '@ember/debug';
 export async function upload(selector, file) {
   let input = find(selector);
   assert(`Selector '${selector}' is not input element.`, input.tagName === 'INPUT');
-  assert(`File must be instance of File type`, file instanceof File || file instanceof Blob);
+  assert(`File must be instance of File/Blob type`, file instanceof Blob);
 
   // This hack is here since we can't mock out the
   // FileList API easily; we're taking advantage

--- a/tests/acceptance/upload-test.js
+++ b/tests/acceptance/upload-test.js
@@ -8,7 +8,7 @@ module('Acceptance | upload', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('upload works', async function(assert) {
+  test('upload works for File', async function(assert) {
     await visit('/');
 
     let data = new Uint8Array([
@@ -20,6 +20,29 @@ module('Acceptance | upload', function(hooks) {
     ]);
 
     let photo = new File([data], 'image.png', { type: 'image/png'});
+    await upload('#upload-photo', photo);
+
+    let uploadedPhoto = this.server.db.photos[0];
+    assert.equal(uploadedPhoto.filename, 'image.png');
+    assert.equal(uploadedPhoto.filesize, 91);
+    assert.equal(uploadedPhoto.type, 'image');
+
+    assert.equal(findAll('.demo-uploaded-files-list img').length, 3, 'Photo is displayed in the UI');
+  });
+
+  test('upload works for Blob', async function(assert) {
+    await visit('/');
+
+    let data = new Uint8Array([
+      137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,8,0,0,
+      0,8,8,2,0,0,0,75,109,41,220,0,0,0,34,73,68,65,84,8,215,99,120,
+      173,168,135,21,49,0,241,255,15,90,104,8,33,129,83,7,97,163,136,
+      214,129,93,2,43,2,0,181,31,90,179,225,252,176,37,0,0,0,0,73,69,
+      78,68,174,66,96,130
+    ]);
+    let photo = new Blob([data], { type: 'image/png' });
+    photo.name = 'image.png';
+
     await upload('#upload-photo', photo);
 
     let uploadedPhoto = this.server.db.photos[0];


### PR DESCRIPTION
Hi there! I hope it's okay that I created a PR right away without creating an issue (I scanned the existing ones before doing so) 🙏

The problem I stumbled upon:
* I run acceptance tests on my app in different browsers. It turned out that Microsoft ones (like Edge and IE) don't support `File` API. Proof link - https://developer.mozilla.org/en-US/docs/Web/API/File/File 😢
* The only way to have tests passing in Microsoft browsers while still being written in the same fashion as this documentation suggests is to use `Blob` instead of the `File`.
* Helper itself can work both with `File` and `Blob` instances without any problems, however before doing any work it checks instanceof File, which in my case basically translates to *This helper can be ran only in non-Microsoft browsers*

The solution is to allow both instances of `File` and `Blob`.

I don't know whether `Blob` is not allowed for a reason or not, but anyway I hope it's a useful change. 🤷‍♂️

Thanks 🙇