### PR TITLE
Move ember-cli-update to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.16.0",
-    "ember-cli-htmlbars": "^3.0.0",
-    "ember-cli-update": "^0.27.3"
+    "ember-cli-htmlbars": "^3.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",
@@ -55,6 +54,7 @@
     "ember-cli-sass": "^8.0.1",
     "ember-cli-template-lint": "^1.0.0-beta.1",
     "ember-cli-uglify": "^2.1.0",
+    "ember-cli-update": "^0.27.3",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^3.4.1",


### PR DESCRIPTION
ember-cli-update shouldn't be a dependency of apps which use ember-file-upload.