### PR TITLE
Fix MIME type checks

### DIFF
--- a/addon/system/data-transfer.js
+++ b/addon/system/data-transfer.js
@@ -82,10 +82,16 @@ export default EmberObject.extend({
       let extensions = A(tokens.filter(function (token) {
         return token.indexOf('.') === 0;
       }));
-      let mimeTypes = A(A(tokens.filter(function (token) {
+      let mimeTypeTests = A(A(tokens.filter(function (token) {
         return token.indexOf('.') !== 0;
       })).map(function (mimeType) {
-        return new RegExp(mimeType);
+        return function(type) {
+          if (A([ 'audio/*', 'video/*', 'image/*' ]).includes(mimeType)) {
+            return type.split('/')[0] === mimeType.split('/')[0];
+          } else {
+            return type === mimeType;
+          }
+        };
       }));
 
       return files.filter(function (file) {
@@ -95,8 +101,8 @@ export default EmberObject.extend({
         }
 
         let type = file.type.toLowerCase();
-        return mimeTypes.find(function (mimeType) {
-          return mimeType.test(type);
+        return mimeTypeTests.find(function (mimeTypeTest) {
+          return mimeTypeTest(type);
         }) || extensions.indexOf(extension) !== -1;
       });
     }

--- a/tests/unit/system/data-transfer-test.js
+++ b/tests/unit/system/data-transfer-test.js
@@ -177,4 +177,50 @@ module('data-transfer', function(hooks) {
     }]);
     assert.notOk(this.subject.get('valid'));
   });
+
+  test('less common mime types', function (assert) {
+    this.subject.set('dataTransfer', {
+      items: [{
+        type: 'image/jpeg'
+      }, {
+        type: 'image/svg+xml'
+      }, {
+        type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+      }]
+    });
+    this.subject.set('queue', {
+      multiple: true,
+      accept: 'image/svg+xml, application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    });
+
+    assert.equal(this.subject.get('files.length'), 2);
+    assert.deepEqual(this.subject.get('files'), [{
+      type: 'image/svg+xml'
+    }, {
+      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    }]);
+    assert.notOk(this.subject.get('valid'));
+  });
+
+  test('mime type case sensitivity', function (assert) {
+    this.subject.set('dataTransfer', {
+      items: [{
+        type: 'image/jPeG'
+      }, {
+        type: 'VIdeo/mp4'
+      }]
+    });
+    this.subject.set('queue', {
+      multiple: true,
+      accept: 'image/JpEg, viDEO/mp4'
+    });
+
+    assert.equal(this.subject.get('files.length'), 2);
+    assert.deepEqual(this.subject.get('files'), [{
+      type: 'image/jPeG'
+    }, {
+      type: 'VIdeo/mp4'
+    }]);
+    assert.ok(this.subject.get('valid'));
+  });
 });


### PR DESCRIPTION
Using a regular expression to check MIME types was problematic and unnecessary. Problematic because it wasn't escaping characters, so for example, `image/svg+xml` would not match because the `+` was interpreted as a 1-or-more modifier on the `g`. Unnecessary because the accept attribute only accepts a very limited set of clearly enumerated type wildcards (see https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)).

So, match more tightly and correctly doing string comparisons, and add some unit tests for this (and to verify case-insensitivity, which was missing for mime types).