### PR TITLE
Fix computed-property.override deprecation

### DIFF
--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -91,6 +91,9 @@ const component = Component.extend({
   for: computed({
     get() {
       return `file-input-${uuid.short()}`;
+    },
+    set(key, value) {
+      return value;
     }
   }),
 


### PR DESCRIPTION
Ember@3.9 deprecates overriding a computed property with .set().

Use didReceiveAttrs() hook to set the default value of the "for" property instead of using a computed property.

Fixes #235