### PR TITLE
request params are not passed through to mirage handler

### DIFF
--- a/addon/mirage/index.js
+++ b/addon/mirage/index.js
@@ -43,17 +43,15 @@ export function upload(fn, options={ network: null, timeout: null }) {
           });
 
           metadata.then((metadata) => {
-            let response = {
-              requestBody: Object.assign({
-                [file.key]: metadata
-              }, data)
-            };
+            request.requestBody = Object.assign({
+              [file.key]: metadata
+            }, data);
             if (timedOut) {
               resolve(new Response(408));
               return;
             }
 
-            resolve(fn.call(this, db, response));
+            resolve(fn.call(this, db, request));
           });
         } else {
           request.upload.onprogress({

--- a/tests/integration/components/mirage-handler-test.js
+++ b/tests/integration/components/mirage-handler-test.js
@@ -1,0 +1,42 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { upload as uploadHandler } from 'ember-file-upload/mirage';
+import { upload } from 'ember-file-upload/test-support';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Integration | Component | mirage-handler', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('upload handler passed schema and request.params throw', async function(assert) {
+    let self = this;
+    this.server.post('/folder/:id/file', uploadHandler(function(schema, request) {
+      assert.step('mirage-handler');
+
+      assert.equal(schema, self.server.schema, 'schema is provided');
+      assert.ok(typeof request.params === 'object', 'params property on request is an object');
+      assert.equal(request.params.id, '1', 'value of dynamic segment is present on params object');
+    }));
+
+    this.set('uploadImage', (file) => {
+      return file.upload('/folder/1/file');
+    });
+    await render(hbs`
+      {{#file-upload
+        name="file"
+        onfileadd=uploadImage
+      }}
+        <a class="button">
+          Upload file
+        </a>
+      {{/file-upload}}
+    `);
+
+    let file = new File(['some-data'], 'text.txt', { type: 'text/plain' });
+    await upload('input', file);
+
+    assert.verifySteps(['mirage-handler']);
+  });
+});

--- a/tests/integration/components/mirage-handler-test.js
+++ b/tests/integration/components/mirage-handler-test.js
@@ -10,7 +10,7 @@ module('Integration | Component | mirage-handler', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  test('upload handler passed schema and request.params throw', async function(assert) {
+  test('upload handler passes schema and request through providing additional file metadata as request body', async function(assert) {
     let self = this;
     this.server.post('/folder/:id/file', uploadHandler(function(schema, request) {
       assert.step('mirage-handler');
@@ -18,6 +18,16 @@ module('Integration | Component | mirage-handler', function(hooks) {
       assert.equal(schema, self.server.schema, 'schema is provided');
       assert.ok(typeof request.params === 'object', 'params property on request is an object');
       assert.equal(request.params.id, '1', 'value of dynamic segment is present on params object');
+      assert.deepEqual(request.requestBody, {
+        'Content-Type': 'text/plain',
+        file: {
+          extension: 'txt',
+          name: 'text.txt',
+          size: 9,
+          type: 'text/plain',
+          url: 'data:text/plain;base64,c29tZS1kYXRh'
+        }
+      });
     }));
 
     this.set('uploadImage', (file) => {


### PR DESCRIPTION
If using the mirage upload handler provided by `ember-file-upload/mirage` the request params are not passed through. This blocks usage of upload handler together with dynamic segments on URLs.

This PR fixes that bug and maybe others caused by replacing the `request` object. Instead it only replaces the `requestBody` property of it. It also adds test coverage for passing through schema and `request.params` to prevent a regression.