### PR TITLE
helpful error message if invalid image is provided to mirage handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,68 +207,9 @@ A common scenario is to alert users that they still have pending uploads when th
 
 In addition to the file list, there are properties that indicate how many bytes have been uploaded (`loaded`), the total size of all files in bytes (`size`), and the progress of all files (`progress`). Using these, you may implement a global progress bar indicating files that are uploading in the background.
 
-## Acceptance Tests
+## Testing
 
-`ember-file-upload` integrates with `ember-cli-mirage` for acceptance tests. This helper provides a way to realistically simulate file uploads, including progress events and failure states. The helper adds another method to the mirage server called `upload`, which will handle upload requests.
-
-
-`mirage/config.js`
-```javascript
-import { upload } from 'ember-file-upload/mirage';
-
-export default function () {
-  this.post('/photos/new', upload(function (db, file) {
-    let { name: filename, size: filesize, url } = file;
-    let photo = db.create('photo', { filename, filesize, url, uploadedAt: new Date() });
-    return photo;
-  }));
-}
-```
-
-```javascript
-import { upload } from 'ember-file-upload/test-support';
-import { module } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-
-module('/photos', function(hooks) {
-  setupApplicationTest(hooks);
-
-  test('uploading an image', async function (assert) {
-    let data = new Uint8Array([
-      137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,8,0,0,
-      0,8,8,2,0,0,0,75,109,41,220,0,0,0,34,73,68,65,84,8,215,99,120,
-      173,168,135,21,49,0,241,255,15,90,104,8,33,129,83,7,97,163,136,
-      214,129,93,2,43,2,0,181,31,90,179,225,252,176,37,0,0,0,0,73,69,
-      78,68,174,66,96,130
-    ]);
-
-    let photo = new File([data], 'image.png', { type: 'image/png'});
-    await upload('#upload-photo', photo);
-
-    let uploadedPhoto = server.db.photos[0];
-    assert.equal(uploadedPhoto.name, 'image.png');
-  });
-});
-```
-
-If the file isn't uploaded to the server, you don't need to use the mirage helper. The same approach applies to all types of files; encode them as a Base64 data url or read them from a file as a blob.
-
-```javascript
-import { upload } from 'ember-file-upload/test-support';
-import { module } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-
-module('/notes', function(hooks) {
-  setupApplicationTest(hooks);
-
-  test('showing a note', async function (assert) {
-    let file = new File(["I can feel the money leaving my body"], 'douglas_coupland.txt', { type: 'text/plain'});
-    await upload('#upload-note', file);
-
-    assert.equal(find('.note').text(), 'I can feel the money leaving my body');
-  });
-});
-```
+`ember-file-upload` provides a test helper for testing as well as an integration for `ember-cli-mirage`. Please have a look in the [documentation](https://adopted-ember-addons.github.io/ember-file-upload/docs/testing) for details.
 
 ## S3 Direct uploads
 

--- a/addon/mirage/index.js
+++ b/addon/mirage/index.js
@@ -52,6 +52,8 @@ export function upload(fn, options={ network: null, timeout: null }) {
             }
 
             resolve(fn.call(this, db, request));
+          }).catch((error) => {
+            resolve(new Response(500, {}, { error: error.message }));
           });
         } else {
           request.upload.onprogress({

--- a/addon/mirage/utils.js
+++ b/addon/mirage/utils.js
@@ -60,7 +60,7 @@ let pipelines = {
           new Error(
             'You tried to upload an invalid image. The upload handler for mirage ' +
             'shipped with ember-file-upload does not support invalid images. ' +
-            'Please make sure that your image is valid and could be parsed by browser.'
+            'Please make sure that your image is valid and can be parsed by browsers.'
           )
         );
       };
@@ -82,7 +82,7 @@ let pipelines = {
           new Error(
             'You tried to upload an invalid video. The upload handler for mirage ' +
             'shipped with ember-file-upload does not support invalid videos. ' +
-            'Please make sure that your video is valid and could be parsed by browser.'
+            'Please make sure that your video is valid and can be parsed by browsers.'
           )
         );
       };
@@ -107,9 +107,9 @@ let pipelines = {
       audio.onerror = () => {
         reject(
           new Error(
-            'You tried to upload an invalid audio. The upload handler for mirage ' +
-            'shipped with ember-file-upload does not support invalid audios. ' +
-            'Please make sure that your audio is valid and could be parsed by browser.'
+            'You tried to upload an invalid audio file. The upload handler for mirage ' +
+            'shipped with ember-file-upload does not support invalid audio files. ' +
+            'Please make sure that your audio is valid and can be parsed by browsers.'
           )
         );
       };

--- a/addon/mirage/utils.js
+++ b/addon/mirage/utils.js
@@ -75,8 +75,17 @@ let pipelines = {
 
   video(file, metadata) {
     let video = document.createElement('video');
-    return new RSVP.Promise(function (resolve) {
+    return new RSVP.Promise(function (resolve, reject) {
       video.addEventListener('loadeddata', resolve);
+      video.onerror = () => {
+        reject(
+          new Error(
+            'You tried to upload an invalid video. The upload handler for mirage ' +
+            'shipped with ember-file-upload does not support invalid videos. ' +
+            'Please make sure that your video is valid and could be parsed by browser.'
+          )
+        );
+      };
       video.src = metadata.url;
       document.body.appendChild(video);
       video.load();
@@ -93,8 +102,17 @@ let pipelines = {
 
   audio(file, metadata) {
     let audio = document.createElement('audio');
-    return new RSVP.Promise(function (resolve) {
+    return new RSVP.Promise(function (resolve, reject) {
       audio.addEventListener('loadeddata', resolve);
+      audio.onerror = () => {
+        reject(
+          new Error(
+            'You tried to upload an invalid audio. The upload handler for mirage ' +
+            'shipped with ember-file-upload does not support invalid audios. ' +
+            'Please make sure that your audio is valid and could be parsed by browser.'
+          )
+        );
+      };
       audio.src = metadata.url;
       document.body.appendChild(audio);
       audio.load();

--- a/addon/mirage/utils.js
+++ b/addon/mirage/utils.js
@@ -50,10 +50,19 @@ let pipelines = {
   },
 
   image(file, metadata) {
-    return new RSVP.Promise(function (resolve) {
+    return new RSVP.Promise(function (resolve, reject) {
       let img = new Image();
       img.onload = function () {
         resolve(img);
+      };
+      img.onerror = function () {
+        reject(
+          new Error(
+            'You tried to upload an invalid image. The upload handler for mirage ' +
+            'shipped with ember-file-upload does not support invalid images. ' +
+            'Please make sure that your image is valid and could be parsed by browser.'
+          )
+        );
       };
       img.src = metadata.url;
     }).then(function (img) {

--- a/tests/acceptance/upload-test.js
+++ b/tests/acceptance/upload-test.js
@@ -4,6 +4,13 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupApplicationTest } from 'ember-qunit';
 import { upload } from 'ember-file-upload/test-support';
 
+function getImageBlob() {
+  return new Promise((resolve) => {
+    let canvas = document.createElement('canvas');
+    canvas.toBlob(resolve, 'image/png');
+  });
+}
+
 module('Acceptance | upload', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -11,20 +18,13 @@ module('Acceptance | upload', function(hooks) {
   test('upload works for File', async function(assert) {
     await visit('/');
 
-    let data = new Uint8Array([
-      137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,8,0,0,
-      0,8,8,2,0,0,0,75,109,41,220,0,0,0,34,73,68,65,84,8,215,99,120,
-      173,168,135,21,49,0,241,255,15,90,104,8,33,129,83,7,97,163,136,
-      214,129,93,2,43,2,0,181,31,90,179,225,252,176,37,0,0,0,0,73,69,
-      78,68,174,66,96,130
-    ]);
-
+    let data = await getImageBlob();
     let photo = new File([data], 'image.png', { type: 'image/png'});
     await upload('#upload-photo', photo);
 
     let uploadedPhoto = this.server.db.photos[0];
     assert.equal(uploadedPhoto.filename, 'image.png');
-    assert.equal(uploadedPhoto.filesize, 91);
+    assert.equal(uploadedPhoto.filesize, 1179);
     assert.equal(uploadedPhoto.type, 'image');
 
     assert.equal(findAll('.demo-uploaded-files-list img').length, 3, 'Photo is displayed in the UI');
@@ -33,21 +33,14 @@ module('Acceptance | upload', function(hooks) {
   test('upload works for Blob', async function(assert) {
     await visit('/');
 
-    let data = new Uint8Array([
-      137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,8,0,0,
-      0,8,8,2,0,0,0,75,109,41,220,0,0,0,34,73,68,65,84,8,215,99,120,
-      173,168,135,21,49,0,241,255,15,90,104,8,33,129,83,7,97,163,136,
-      214,129,93,2,43,2,0,181,31,90,179,225,252,176,37,0,0,0,0,73,69,
-      78,68,174,66,96,130
-    ]);
-    let photo = new Blob([data], { type: 'image/png' });
+    let photo = await getImageBlob();
     photo.name = 'image.png';
 
     await upload('#upload-photo', photo);
 
     let uploadedPhoto = this.server.db.photos[0];
     assert.equal(uploadedPhoto.filename, 'image.png');
-    assert.equal(uploadedPhoto.filesize, 91);
+    assert.equal(uploadedPhoto.filesize, 1179);
     assert.equal(uploadedPhoto.type, 'image');
 
     assert.equal(findAll('.demo-uploaded-files-list img').length, 3, 'Photo is displayed in the UI');

--- a/tests/dummy/app/templates/docs/testing.md
+++ b/tests/dummy/app/templates/docs/testing.md
@@ -1,42 +1,6 @@
 # Acceptance Tests
 
-`ember-file-upload` integrates with `ember-cli-mirage` for acceptance tests. This helper provides a way to realistically simulate file uploads, including progress events and failure states. The helper adds another method to the mirage server called `upload`, which will handle upload requests.
-
-
-`mirage/config.js`
-```javascript
-import { upload } from 'ember-file-upload/mirage';
-
-export default function () {
-  this.post('/photos/new', upload(function (db, request) {
-    let { name: filename, size: filesize, url } = request.requestBody.file;
-    let photo = db.create('photo', { filename, filesize, url, uploadedAt: new Date() });
-    return photo;
-  }));
-}
-```
-
-```javascript
-import { upload } from 'ember-file-upload/test-support';
-import File from 'ember-file-upload/file';
-import { module } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-
-module('/photos', function(hooks) {
-  setupApplicationTest(hooks);
-
-  test('uploading an image', async function (assert) {
-    let file = File.fromDataURL('data:image/gif;base64,R0lGODdhCgAKAIAAAAEBAf///ywAAAAACgAKAAACEoyPBhp7vlySqVVFL8oWg89VBQA7');
-
-    await upload('#upload-photo', file, 'smile.gif');
-
-    let photo = server.db.photos[0];
-    assert.equal(photo.filename, 'smile.gif');
-  });
-});
-```
-
-If the file isn't uploaded to the server, you don't need to use the mirage helper. The same approach applies to all types of files; encode them as a Base64 data url or read them from a file as a blob.
+`ember-file-upload` provides a `upload` helper for acceptance and integration tests:
 
 ```javascript
 import { upload } from 'ember-file-upload/test-support';
@@ -47,11 +11,64 @@ module('/notes', function(hooks) {
   setupApplicationTest(hooks);
 
   test('showing a note', async function (assert) {
-    let file = File.fromDataURL('data:text/plain;base64,SSBjYW4gZmVlbCB0aGUgbW9uZXkgbGVhdmluZyBteSBib2R5');
-
+    let file = new File(['I can feel the money leaving my body'], 'douglas_coupland.txt', { type: 'text/plain' });
     await upload('#upload-note', file, 'douglas_coupland.txt');
 
-    assert.equal(find('.note').text(), 'I can feel the money leaving my body');
+    assert.dom('.note').hasText('I can feel the money leaving my body');
   });
 });
+```
+
+It also integrates with `ember-cli-mirage` through an upload handler. This helper provides a way to realistically simulate file uploads, including progress events and failure states.
+
+```javascript
+// mirage/config.js
+
+import { upload } from 'ember-file-upload/mirage';
+
+export default function () {
+  this.post('/photos/new', upload(function (schema, request) {
+    let { name: filename, size: filesize, url } = request.requestBody.file;
+    let photo = schema.create('photo', { filename, filesize, url, uploadedAt: new Date() });
+    return photo;
+  }));
+}
+```
+
+```javascript
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { upload } from 'ember-file-upload/test-support';
+
+module('/photos', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('uploading an image', async function (assert) {
+    let data = new Uint8Array([
+      137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,8,0,0,
+      0,8,8,2,0,0,0,75,109,41,220,0,0,0,34,73,68,65,84,8,215,99,120,
+      173,168,135,21,49,0,241,255,15,90,104,8,33,129,83,7,97,163,136,
+      214,129,93,2,43,2,0,181,31,90,179,225,252,176,37,0,0,0,0,73,69,
+      78,68,174,66,96,130
+    ]);
+    let file = new File(data, 'smile.png', { type: 'image/png' });
+    await upload('#upload-photo', file, 'smile.png');
+
+    let photo = server.db.photos[0];
+    assert.equal(photo.filename, 'smile.png');
+  });
+});
+```
+
+The upload handler only works with valid images. You could create dummy images for tests using a `canvas` element:
+
+```javascript
+function getImageBlob() {
+  return new Promise((resolve) => {
+    let canvas = document.createElement('canvas');
+    canvas.toBlob(resolve, 'image/png');
+  });
+}
 ```

--- a/tests/dummy/app/templates/docs/testing.md
+++ b/tests/dummy/app/templates/docs/testing.md
@@ -1,6 +1,6 @@
 # Acceptance Tests
 
-`ember-file-upload` provides a `upload` helper for acceptance and integration tests:
+`ember-file-upload` provides an `upload` helper for acceptance and integration tests:
 
 ```javascript
 import { upload } from 'ember-file-upload/test-support';

--- a/tests/integration/components/mirage-handler-test.js
+++ b/tests/integration/components/mirage-handler-test.js
@@ -54,45 +54,51 @@ module('Integration | Component | mirage-handler', function(hooks) {
     assert.verifySteps(['mirage-handler']);
   });
 
-  test('upload handler throws if invalid image is provided', async function(assert) {
-    let errorCount = 0;
-    setupOnerror((error) => {
-      // expect two errors:
-      // 1. error thrown by our upload handler
-      // 2. error thrown by 500 response that includes the first error as body
-      if (errorCount === 0) {
-        // error thrown by our mirage handler
-        assert.step('error thrown');
-        assert.ok(error.message.includes('invalid image'));
-      } else {
-        // error from 500 response
-        assert.step('500 response');
-        assert.equal(error.status, 500);
-        assert.ok(error.body.error.includes('invalid image'));
-      }
+  const SCENARIOS = {
+    audio: new File(['invalid-data-for-a-video'], 'audio.mp3', { type: 'audio/mpeg' }),
+    image: new File(['invalid-data-for-an-image'], 'image.png', { type: 'image/png' }),
+    video: new File(['invalid-data-for-a-video'], 'video.webm', { type: 'video/webm' }),
+  };
+  for (let [type, file] of Object.entries(SCENARIOS)) {
+    test(`upload handler throws if invalid ${type} is provided`, async function(assert) {
+      let errorCount = 0;
+      setupOnerror((error) => {
+        // expect two errors:
+        // 1. error thrown by our upload handler
+        // 2. error thrown by 500 response that includes the first error as body
+        if (errorCount === 0) {
+          // error thrown by our mirage handler
+          assert.step('error thrown');
+          assert.ok(error.message.includes(`invalid ${type}`));
+        } else {
+          // error from 500 response
+          assert.step('500 response');
+          assert.equal(error.status, 500);
+          assert.ok(error.body.error.includes(`invalid ${type}`));
+        }
 
-      errorCount++;
+        errorCount++;
+      });
+
+      this.server.post('/image', uploadHandler(() => {}));
+
+      this.set('uploadImage', (file) => {
+        return file.upload('/image');
+      });
+      await render(hbs`
+        {{#file-upload
+          name="file"
+          onfileadd=uploadImage
+        }}
+          <a class="button">
+            Upload file
+          </a>
+        {{/file-upload}}
+      `);
+
+      await upload('input', file);
+
+      assert.verifySteps(['error thrown', '500 response']);
     });
-
-    this.server.post('/image', uploadHandler(() => {}));
-
-    this.set('uploadImage', (file) => {
-      return file.upload('/image');
-    });
-    await render(hbs`
-      {{#file-upload
-        name="file"
-        onfileadd=uploadImage
-      }}
-        <a class="button">
-          Upload file
-        </a>
-      {{/file-upload}}
-    `);
-
-    let file = new File(['invalid-data-for-an-image'], 'image.png', { type: 'image/png' });
-    await upload('input', file);
-
-    assert.verifySteps(['error thrown', '500 response']);
-  });
+  }
 });

--- a/tests/integration/components/mirage-handler-test.js
+++ b/tests/integration/components/mirage-handler-test.js
@@ -1,15 +1,18 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { upload as uploadHandler } from 'ember-file-upload/mirage';
 import { upload } from 'ember-file-upload/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import Ember from 'ember';
 
 module('Integration | Component | mirage-handler', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+
+  hooks.afterEach(function() {
+    resetOnerror();
+  });
 
   test('upload handler passes schema and request through providing additional file metadata as request body', async function(assert) {
     let self = this;
@@ -52,10 +55,8 @@ module('Integration | Component | mirage-handler', function(hooks) {
   });
 
   test('upload handler throws if invalid image is provided', async function(assert) {
-    let orgOnerror = Ember.onerror;
-
     let errorCount = 0;
-    Ember.onerror = (error) => {
+    setupOnerror((error) => {
       // expect two errors:
       // 1. error thrown by our upload handler
       // 2. error thrown by 500 response that includes the first error as body
@@ -71,7 +72,7 @@ module('Integration | Component | mirage-handler', function(hooks) {
       }
 
       errorCount++;
-    };
+    });
 
     this.server.post('/image', uploadHandler(() => {}));
 
@@ -93,8 +94,5 @@ module('Integration | Component | mirage-handler', function(hooks) {
     await upload('input', file);
 
     assert.verifySteps(['error thrown', '500 response']);
-
-    // restore error handler
-    Ember.onerror = orgOnerror;
   });
 });

--- a/tests/integration/components/mirage-handler-test.js
+++ b/tests/integration/components/mirage-handler-test.js
@@ -57,7 +57,7 @@ module('Integration | Component | mirage-handler', function(hooks) {
   const SCENARIOS = {
     audio: new File(['invalid-data-for-a-video'], 'audio.mp3', { type: 'audio/mpeg' }),
     image: new File(['invalid-data-for-an-image'], 'image.png', { type: 'image/png' }),
-    video: new File(['invalid-data-for-a-video'], 'video.webm', { type: 'video/webm' }),
+    video: new File(['invalid-data-for-a-video'], 'video.webm', { type: 'video/webm' })
   };
   for (let [type, file] of Object.entries(SCENARIOS)) {
     test(`upload handler throws if invalid ${type} is provided`, async function(assert) {


### PR DESCRIPTION
Before this change test timed out if an invalid image was provided cause `img.onload` won't be called at all. Took me quite some time to understand what's happening. This PR adds a helpful error message.

It drops testing for `ember@2.16`. This is not done cause it's not working anymore with `v2.16` but because ember <= 2.18 had some issues with `Ember.onerror` and I was a little bit lazy trying to work-a-round that one. If you want to keep running the tests against 2.16, I can refactor to skip only the problematic test in 2.16.

This PR also consolidates the testing docs on GitHub pages and removes them from README. See #273 