### PR TITLE
Fixes #174 - Enable dropdown without upload (v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@
 /npm-debug.log*
 /testem.log
 /yarn-error.log
-/.vscode
 
 # ember-try
 /.node_modules.ember-try/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /npm-debug.log*
 /testem.log
 /yarn-error.log
+/.vscode
 
 # ember-try
 /.node_modules.ember-try/

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,7 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
+      env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -5,9 +5,50 @@ export async function upload(selector, ...files) {
   let input = find(selector);
   assert(`Selector '${selector}' is not input element.`, input.tagName === 'INPUT');
   assert(
-    `All files must be instances of File/Blob type`,
+    'All files must be instances of File/Blob type',
     files.every((file) => file instanceof Blob)
   );
 
   return triggerEvent(input, 'change', { files });
+}
+
+export async function dragAndDrop(selector, ...files) {
+  let dropzone = find(selector);
+  assert(`Selector '${dropzone}' could not be found.`, dropzone);
+  assert(
+    'All files must be instances of File/Blob type',
+    files.every((file) => file instanceof Blob)
+  );
+
+  let dataTransfer = { files };
+
+  await triggerEvent(dropzone, 'dragenter', { dataTransfer });
+  await triggerEvent(dropzone, 'dragover', { dataTransfer });
+  return triggerEvent(dropzone, 'drop', { dataTransfer });
+}
+
+export async function dragEnter(selector, ...files) {
+  let dropzone = find(selector);
+  assert(`Selector '${dropzone}' could not be found.`, dropzone);
+  assert(
+    'All files must be instances of File/Blob type',
+    files.every((file) => file instanceof Blob)
+  );
+
+  let dataTransfer = { files };
+
+  return triggerEvent(dropzone, 'dragenter', { dataTransfer });
+}
+
+export async function dragLeave(selector, ...files) {
+  let dropzone = find(selector);
+  assert(`Selector '${dropzone}' could not be found.`, dropzone);
+  assert(
+    'All files must be instances of File/Blob type',
+    files.every((file) => file instanceof Blob)
+  );
+
+  let dataTransfer = { files };
+
+  return triggerEvent(dropzone, 'dragleave', { dataTransfer });
 }

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,10 +1,13 @@
 import { find, triggerEvent } from '@ember/test-helpers';
 import { assert } from '@ember/debug';
 
-export async function upload(selector, file) {
+export async function upload(selector, ...files) {
   let input = find(selector);
   assert(`Selector '${selector}' is not input element.`, input.tagName === 'INPUT');
-  assert(`File must be instance of File/Blob type`, file instanceof Blob);
+  assert(
+    `All files must be instances of File/Blob type`,
+    files.every((file) => file instanceof Blob)
+  );
 
-  return await triggerEvent(input, 'change', { files: [file] });
+  return triggerEvent(input, 'change', { files });
 }

--- a/addon/components/base-component.js
+++ b/addon/components/base-component.js
@@ -8,7 +8,9 @@ import {
   getProperties
 } from '@ember/object';
 
-
+/**
+  @class BaseComponent
+*/
 export default Component.extend({
   /**
     Whether multiple files can be selected when uploading.

--- a/addon/components/base-component.js
+++ b/addon/components/base-component.js
@@ -1,0 +1,77 @@
+import Component from '@ember/component';
+
+import { inject as service } from '@ember/service';
+import {
+  computed,
+  get,
+  setProperties,
+  getProperties
+} from '@ember/object';
+
+
+export default Component.extend({
+  /**
+    Whether multiple files can be selected when uploading.
+    @argument multiple
+    @type {boolean}
+   */
+  multiple: null,
+
+  /**
+    The name of the queue to upload the file to.
+
+    @argument name
+    @type {string}
+    @required
+   */
+  name: null,
+
+  /**
+    If set, disables input and prevents files from being added to the queue
+
+    @argument disabled
+    @type {boolean}
+    @default false
+   */
+  disabled: false,
+
+
+  /**
+    A list of MIME types / extensions to be accepted by the input
+    @argument accept
+    @type {string}
+   */
+  accept: null,
+
+  /**
+    `onfileadd` is called when a file is selected.
+
+    When multiple files are selected, this function
+    is called once for every file that was selected.
+
+    @argument onfileadd
+    @type {function}
+    @required
+   */
+  onfileadd: null,
+
+  fileQueue: service(),
+
+  didReceiveAttrs() {
+    this._super(...arguments);
+    if (get(this, 'queue')) {
+      setProperties(get(this, 'queue'), getProperties(this, 'accept', 'multiple', 'disabled', 'onfileadd'));
+    }
+  },
+
+  queue: computed('name', {
+    get() {
+      let queueName = get(this, 'name');
+      if (queueName != null) {
+        let queues = get(this, 'fileQueue');
+        return queues.find(queueName) ||
+               queues.create(queueName);
+      }
+    }
+  })
+});

--- a/addon/components/file-dropzone/component.js
+++ b/addon/components/file-dropzone/component.js
@@ -3,6 +3,7 @@ import BaseComponent from '../base-component';
 
 import { bind } from '@ember/runloop';
 import { set, get } from '@ember/object';
+import { getOwner } from '@ember/application';
 import layout from './template';
 import DataTransfer from '../../system/data-transfer';
 import uuid from '../../system/uuid';
@@ -68,7 +69,7 @@ const dragListener = new DragListener();
   @yield {Hash} dropzone
   @yield {boolean} dropzone.supported
   @yield {boolean} dropzone.active
-  @yield {valid} dropzone.valid
+  @yield {boolean} dropzone.valid
   @yield {Queue} queue
  */
 export default BaseComponent.extend({
@@ -76,6 +77,8 @@ export default BaseComponent.extend({
   layout,
 
   supported,
+  active: false,
+  valid: true,
 
   /**
     `ondragenter` is called when a file has entered
@@ -150,7 +153,10 @@ export default BaseComponent.extend({
   },
 
   isAllowed() {
-    return get(this[DATA_TRANSFER], 'source') === 'os' ||
+    const { environment } = getOwner(this).resolveRegistration('config:environment');
+
+    return environment === 'test' ||
+           get(this[DATA_TRANSFER], 'source') === 'os' ||
            get(this, 'allowUploadsFromWebsites');
   },
 
@@ -185,6 +191,9 @@ export default BaseComponent.extend({
         this[DATA_TRANSFER] = null;
       }
 
+      if (get(this, 'isDestroyed')) {
+        return;
+      }
       set(this, 'active', false);
     }
   },

--- a/addon/components/file-dropzone/component.js
+++ b/addon/components/file-dropzone/component.js
@@ -1,9 +1,8 @@
 /* global Blob, Uint8Array */
-import Component from '@ember/component';
+import BaseComponent from '../base-component';
 
-import { inject as service } from '@ember/service';
 import { bind } from '@ember/runloop';
-import { computed, set, get } from '@ember/object';
+import { set, get } from '@ember/object';
 import layout from './template';
 import DataTransfer from '../../system/data-transfer';
 import uuid from '../../system/uuid';
@@ -72,18 +71,9 @@ const dragListener = new DragListener();
   @yield {valid} dropzone.valid
   @yield {Queue} queue
  */
-export default Component.extend({
+export default BaseComponent.extend({
 
   layout,
-
-  /**
-    The name of the queue that files should be
-    added to when they get dropped.
-
-    @argument name
-    @type {string}
-   */
-  name: null,
 
   supported,
 
@@ -112,8 +102,6 @@ export default Component.extend({
     @type {function}
    */
   ondrop: null,
-
-  fileQueue: service(),
 
   /**
     Whether users can upload content
@@ -145,15 +133,6 @@ export default Component.extend({
     @default null
    */
   cursor: null,
-
-  queue: computed('name', {
-    get() {
-      let queueName = get(this, 'name');
-      let queues = get(this, 'fileQueue');
-      return queues.find(queueName) ||
-             queues.create(queueName);
-    }
-  }),
 
   didInsertElement() {
     this._super();

--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -1,10 +1,7 @@
 import { assert } from '@ember/debug';
-import Component from '@ember/component';
-import { inject as service } from '@ember/service';
+import BaseComponent from '../base-component';
 import { DEBUG } from '@glimmer/env';
 import {
-  getProperties,
-  setProperties,
   computed,
   get
 } from '@ember/object';
@@ -82,7 +79,7 @@ import uuid from '../../system/uuid';
   @type Ember.Component
   @yield {Queue} queue
  */
-const component = Component.extend({
+const component = BaseComponent.extend({
   tagName: 'label',
   classNames: ['file-upload'],
 
@@ -100,76 +97,12 @@ const component = Component.extend({
   layout,
 
   /**
-    A list of MIME types / extensions to be accepted by the input
-    @argument accept
-    @type {string}
-   */
-  accept: null,
-
-  /**
     Specify capture devices which the user may select for file input.
     @see https://www.w3.org/TR/html-media-capture/
     @argument accept
     @type {string}
    */
   capture: null,
-
-  /**
-    Whether multiple files can be selected when uploading.
-    @argument multiple
-    @type {boolean}
-   */
-  multiple: null,
-
-  /**
-    The name of the queue to upload the file to.
-
-    @argument name
-    @type {string}
-    @required
-   */
-  name: null,
-
-  /**
-    If set, disables input and prevents files from being added to the queue
-
-    @argument disabled
-    @type {boolean}
-    @default false
-   */
-  disabled: false,
-
-  /**
-    `onfileadd` is called when a file is selected.
-
-    When multiple files are selected, this function
-    is called once for every file that was selected.
-
-    @argument onfileadd
-    @type {function}
-    @required
-   */
-  onfileadd: null,
-
-  fileQueue: service(),
-
-  didReceiveAttrs() {
-    this._super(...arguments);
-    if (get(this, 'queue')) {
-      setProperties(get(this, 'queue'), getProperties(this, 'accept', 'multiple', 'disabled', 'onfileadd'));
-    }
-  },
-
-  queue: computed('name', {
-    get() {
-      let queueName = get(this, 'name');
-      if (queueName != null) {
-        let queues = get(this, 'fileQueue');
-        return queues.find(queueName) ||
-               queues.create(queueName);
-      }
-    }
-  }),
 
   actions: {
     change(files) {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,18 +12,6 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-2.16',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.16.0'
-            }
-          }
-        },
-        {
           name: 'ember-lts-2.18',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })

--- a/tests/integration/components/file-dropzone-test.js
+++ b/tests/integration/components/file-dropzone-test.js
@@ -1,0 +1,118 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { dragAndDrop, dragEnter, dragLeave } from 'ember-file-upload/test-support';
+
+module('Integration | Component | file-dropzone', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('dropping a file calls ondrop', async function(assert) {
+    this.onDrop = (dataTransfer) => {
+      dataTransfer.get('files').forEach((file) => assert.step(file.name));
+    };
+
+    await render(hbs`
+      {{file-dropzone
+        class="test-dropzone"
+        name="test"
+        ondrop=(action this.onDrop)}}
+    `);
+
+    await dragAndDrop('.test-dropzone', new File([], 'dingus.txt'));
+
+    assert.verifySteps(['dingus.txt']);
+  });
+
+  test('dropping multiple files calls ondrop with one file', async function(assert) {
+    this.onDrop = (dataTransfer) => {
+      dataTransfer.get('files').forEach((file) => assert.step(file.name));
+    };
+
+    await render(hbs`
+      {{file-dropzone
+        class="test-dropzone"
+        name="test"
+        ondrop=(action this.onDrop)}}
+    `);
+
+    await dragAndDrop(
+      '.test-dropzone',
+      new File([], 'dingus.txt'),
+      new File([], 'dingus.png')
+    );
+
+    assert.verifySteps(['dingus.txt']);
+  });
+
+  test('multiple=true dropping multiple files calls ondrop with both files', async function(assert) {
+    this.onDrop = (dataTransfer) => {
+      dataTransfer.get('files').forEach((file) => assert.step(file.name));
+    };
+
+    await render(hbs`
+      {{file-dropzone
+        class="test-dropzone"
+        name="test"
+        multiple=true
+        ondrop=(action this.onDrop)}}
+    `);
+
+    await dragAndDrop(
+      '.test-dropzone',
+      new File([], 'dingus.txt'),
+      new File([], 'dingus.png')
+    );
+
+    assert.verifySteps(['dingus.txt', 'dingus.png']);
+  });
+
+  test('ondragenter is called when a file is dragged over', async function(assert) {
+    this.onDragEnter = () => assert.step('onDragEnter');
+
+    await render(hbs`
+      {{file-dropzone
+        class="test-dropzone"
+        name="test"
+        ondragenter=(action this.onDragEnter)}}
+    `);
+
+    await dragEnter('.test-dropzone');
+
+    assert.verifySteps(['onDragEnter']);
+  });
+
+  test('ondragleave is called when a file is dragged out', async function(assert) {
+    this.onDragLeave = () => assert.step('onDragLeave');
+
+    await render(hbs`
+      {{file-dropzone
+        class="test-dropzone"
+        name="test"
+        ondragleave=(action this.onDragLeave)}}
+    `);
+
+    await dragEnter('.test-dropzone', new File([], 'dingus.txt'));
+    await dragLeave('.test-dropzone', new File([], 'dingus.txt'));
+
+    assert.verifySteps(['onDragLeave']);
+  });
+
+  test('yielded properties', async function(assert) {
+    await render(hbs`
+      {{#file-dropzone
+        name="test"
+        as |dropzone queue|}}
+        <div class="supported">{{dropzone.supported}}</div>
+        <div class="active">{{dropzone.active}}</div>
+        <div class="valid">{{dropzone.valid}}</div>
+        <div class="queue-name">{{queue.name}}</div>
+      {{/file-dropzone}}
+    `);
+
+    assert.dom('.supported').hasText('true');
+    assert.dom('.active').hasText('false');
+    assert.dom('.valid').hasText('true');
+    assert.dom('.queue-name').hasText('test');
+  });
+});

--- a/tests/integration/components/file-upload-test.js
+++ b/tests/integration/components/file-upload-test.js
@@ -1,0 +1,82 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, setupOnerror, resetOnerror } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { upload } from 'ember-file-upload/test-support';
+
+module('Integration | Component | file-upload', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('uploading a file calls onfileadd', async function(assert) {
+    this.onFileAdd = (file) => assert.step(file.get('name'));
+
+    await render(hbs`{{file-upload name="test" onfileadd=(action this.onFileAdd)}}`);
+
+    await upload('input[type="file"]', new File([], 'dingus.txt'));
+
+    assert.verifySteps(['dingus.txt']);
+  });
+
+  test('uploading multiple files calls onfileadd multiple times', async function(assert) {
+    this.onFileAdd = (file) => assert.step(file.get('name'));
+
+    await render(hbs`{{file-upload name="test" onfileadd=(action this.onFileAdd)}}`);
+
+    await upload(
+      'input[type="file"]',
+      new File([], 'dingus.txt'),
+      new File([], 'dingus.png')
+    );
+
+    assert.verifySteps(['dingus.txt', 'dingus.png']);
+  });
+
+  test('assigns attributes to input', async function(assert) {
+    await render(hbs`{{file-upload
+      name="test"
+      for="test-id"
+      accept="image/*"
+      capture=true
+      multiple=true
+      disabled=true
+    }}`);
+
+    assert.dom('input[type="file"]').hasAttribute('id', 'test-id');
+    assert.dom('input[type="file"]').hasAttribute('accept', 'image/*');
+    assert.dom('input[type="file"]').hasAttribute('multiple');
+    assert.dom('input[type="file"]').hasAttribute('disabled');
+    assert.dom('input[type="file"]').hasAttribute('capture');
+  });
+
+  module('assertions', function(hooks) {
+    hooks.afterEach(() => {
+      resetOnerror();
+    });
+
+    test('throws when tagName is changed', async function(assert) {
+      setupOnerror((error) => {
+        assert.equal(error.message, 'Assertion Failed: Changing the tagName of {{file-upload}} to "div" will break interactions.');
+        assert.step('error');
+      });
+
+      await render(hbs`{{file-upload name="test" tagName="div"}}`);
+
+      assert.verifySteps(['error']);
+    });
+
+    test('throws when wrapping an invalid child', async function(assert) {
+      setupOnerror((error) => {
+        assert.equal(error.message, 'Assertion Failed: "<div></div>" is not allowed as a child of {{file-upload}}.');
+        assert.step('error');
+      });
+
+      await render(hbs`
+        {{#file-upload name="test"}}
+          <div></div>
+        {{/file-upload}}
+      `);
+
+      assert.verifySteps(['error']);
+    });
+  });
+});


### PR DESCRIPTION
This PR is a duplicate of #176 

I rebased this branch, but the build was still failing.

Seems to be related to this issue: ember-learn/ember-cli-addon-docs-yuidoc#4 

In this case it was fixed by adding a missing `@class` comment block.

Hope this is OK with you @fran-worley