### PR TITLE
Fix Travis CI Badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# {{file-upload}} [![Build Status](https://travis-ci.org/adopted-ember-addons/ember-file-upload.svg)](https://travis-ci.org/adopted-ember-addons/ember-file-upload) [![Code Climate](https://codeclimate.com/github/adopted-ember-addons/ember-file-upload/badges/gpa.svg)](https://codeclimate.com/github/adopted-ember-addons/ember-file-upload) [![Ember Observer Score](https://emberobserver.com/badges/ember-file-upload.svg)](https://emberobserver.com/addons/ember-file-upload)
+# {{file-upload}} [![Build Status](https://travis-ci.org/adopted-ember-addons/ember-file-upload.svg?branch=latest)](https://travis-ci.org/adopted-ember-addons/ember-file-upload) [![Code Climate](https://codeclimate.com/github/adopted-ember-addons/ember-file-upload/badges/gpa.svg)](https://codeclimate.com/github/adopted-ember-addons/ember-file-upload) [![Ember Observer Score](https://emberobserver.com/badges/ember-file-upload.svg)](https://emberobserver.com/addons/ember-file-upload)
 
 {{file-upload}} is an ember component that provides an API for file uploads. Uploads are persistent across routes in your application (they continue in the background).
 


### PR DESCRIPTION
Not sure if this is how it's done, but it seems to work.

This seems consistent with [the Travis CI page](https://travis-ci.org/adopted-ember-addons/ember-file-upload).


Before:
[![Build Status](https://travis-ci.org/adopted-ember-addons/ember-file-upload.svg)](https://travis-ci.org/adopted-ember-addons/ember-file-upload)

After:
[![Build Status](https://api.travis-ci.org/adopted-ember-addons/ember-file-upload.svg?branch=latest)](https://travis-ci.org/adopted-ember-addons/ember-file-upload)