### PR TITLE
Documented test-support test helper functions.

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,6 +1,33 @@
 import { find, triggerEvent } from '@ember/test-helpers';
 import { assert } from '@ember/debug';
 
+/**
+  Triggers a `change` event on a `FileUpload` input with `files`.
+
+  All `files` must be [HTML5 File objects](https://developer.mozilla.org/en-US/docs/Web/API/File).
+
+  A single file, or multiple files may be passed as arguments.
+
+  ```javascript
+    // A single file
+    const file = new File([], 'dingus.txt');
+    await upload('.file-upload input', file);
+  ```
+
+  ```javascript
+    // Multiple files
+    const file1 = new File([], 'dingus1.txt');
+    const file2 = new File([], 'dingus2.txt');
+    await upload('.file-upload input', file1, file2);
+  ```
+
+  Returns `Promise<void>` which resolves when the application is settled.
+
+  @function upload
+  @param {String} selector DOM selector for a FileUpload input
+  @param {File} ...files One or more File objects
+  @return {Promise}
+ */
 export async function upload(selector, ...files) {
   let input = find(selector);
   assert(`Selector '${selector}' is not input element.`, input.tagName === 'INPUT');
@@ -12,6 +39,33 @@ export async function upload(selector, ...files) {
   return triggerEvent(input, 'change', { files });
 }
 
+/**
+  Triggers `dragenter`, `dragover`, and `drop` events on a `FileDropzone` with `files`.
+
+  All `files` must be [HTML5 File objects](https://developer.mozilla.org/en-US/docs/Web/API/File).
+
+  A single file, or multiple files may be passed as arguments.
+
+  ```javascript
+    // A single file
+    const file = new File([], 'dingus.txt');
+    await dragAndDrop('.file-dropzone', file);
+  ```
+
+  ```javascript
+    // Multiple files
+    const file1 = new File([], 'dingus1.txt');
+    const file2 = new File([], 'dingus2.txt');
+    await dragAndDrop('.file-dropzone', file1, file2);
+  ```
+
+  Returns `Promise<void>` which resolves when the application is settled.
+
+  @function dragAndDrop
+  @param {String} selector DOM selector for a FileDropzone
+  @param {File} ...files One or more File objects
+  @return {Promise}
+ */
 export async function dragAndDrop(selector, ...files) {
   let dropzone = find(selector);
   assert(`Selector '${dropzone}' could not be found.`, dropzone);
@@ -27,6 +81,33 @@ export async function dragAndDrop(selector, ...files) {
   return triggerEvent(dropzone, 'drop', { dataTransfer });
 }
 
+/**
+  Triggers a `dragenter` event on a `FileDropzone` with `files`.
+
+  All `files` must be [HTML5 File objects](https://developer.mozilla.org/en-US/docs/Web/API/File).
+
+  A single file, or multiple files may be passed as arguments.
+
+  ```javascript
+    // A single file
+    const file = new File([], 'dingus.txt');
+    await dragEnter('.file-dropzone', file);
+  ```
+
+  ```javascript
+    // Multiple files
+    const file1 = new File([], 'dingus1.txt');
+    const file2 = new File([], 'dingus2.txt');
+    await dragEnter('.file-dropzone', file1, file2);
+  ```
+
+  Returns `Promise<void>` which resolves when the application is settled.
+
+  @function dragEnter
+  @param {String} selector DOM selector for a FileDropzone
+  @param {File} ...files One or more File objects
+  @return {Promise}
+ */
 export async function dragEnter(selector, ...files) {
   let dropzone = find(selector);
   assert(`Selector '${dropzone}' could not be found.`, dropzone);
@@ -40,6 +121,33 @@ export async function dragEnter(selector, ...files) {
   return triggerEvent(dropzone, 'dragenter', { dataTransfer });
 }
 
+/**
+  Triggers a `dragleave` event on a `FileDropzone` with `files`.
+
+  All `files` must be [HTML5 File objects](https://developer.mozilla.org/en-US/docs/Web/API/File).
+
+  A single file, or multiple files may be passed as arguments.
+
+  ```javascript
+    // A single file
+    const file = new File([], 'dingus.txt');
+    await dragLeave('.file-dropzone', file);
+  ```
+
+  ```javascript
+    // Multiple files
+    const file1 = new File([], 'dingus1.txt');
+    const file2 = new File([], 'dingus2.txt');
+    await dragLeave('.file-dropzone', file1, file2);
+  ```
+
+  Returns `Promise<void>` which resolves when the application is settled.
+
+  @function dragLeave
+  @param {String} selector DOM selector for a FileDropzone
+  @param {File} ...files One or more File objects
+  @return {Promise}
+ */
 export async function dragLeave(selector, ...files) {
   let dropzone = find(selector);
   assert(`Selector '${dropzone}' could not be found.`, dropzone);


### PR DESCRIPTION
Adds a `Modules > ember-file-upload > test-support` section under `API REFERENCE` on the documentation site.
