### PR TITLE
Dedup default property values in BaseComponent

### DIFF
--- a/addon/components/base-component.js
+++ b/addon/components/base-component.js
@@ -9,12 +9,6 @@ import {
 } from '@ember/object';
 
 export default Component.extend({
-  multiple: null,
-  name: null,
-  disabled: false,
-  accept: null,
-  onfileadd: null,
-
   fileQueue: service(),
 
   didReceiveAttrs() {


### PR DESCRIPTION
Removed shared properties from `BaseComponent` since they are overridden in both `FileDropzone` and `FileUpload`.

Requested in #281