### PR TITLE
fix triple curly in file-dropzone doc

### DIFF
--- a/addon/components/file-dropzone/component.js
+++ b/addon/components/file-dropzone/component.js
@@ -24,7 +24,7 @@ const dragListener = new DragListener();
    drag and drop.
 
   ```hbs
-  {{{#file-dropzone name="photos" as |dropzone queue|}}
+  {{#file-dropzone name="photos" as |dropzone queue|}}
     {{#if dropzone.active}}
       {{#if dropzone.valid}}
         Drop to upload


### PR DESCRIPTION
I noticed there was an extra curly in the example for file-dropzone in the docs.