### PR TITLE
Remove observers

### DIFF
--- a/addon/file.js
+++ b/addon/file.js
@@ -102,6 +102,7 @@ function upload(file, url, opts, uploadFn) {
     set(file, 'state', 'failed');
     return RSVP.reject(error);
   }).finally(function () {
+    get(file, 'queue').flush();
     // Decrement for Ember.Test
     inflightRequests--;
   });
@@ -218,6 +219,8 @@ export default EmberObject.extend({
     - `aborted`
     - `uploaded`
     - `failed`
+
+    Implementers should call flush() on the file's queue after mutating this property.
 
     @accessor state
     @type {String}

--- a/addon/mixins/with-files.js
+++ b/addon/mixins/with-files.js
@@ -1,0 +1,86 @@
+import Mixin from '@ember/object/mixin';
+import { A } from '@ember/array';
+import { computed, set, get } from '@ember/object';
+import sumBy from '../computed/sum-by';
+
+export default Mixin.create({
+  /**
+    Flushes the `files` property if they have settled. This
+    will only flush files when all files have arrived at a terminus
+    of their state chart.
+
+    ```
+        .------.     .---------.     .--------.
+    o--| queued |-->| uploading |-->| uploaded |
+        `------`     `---------`     `--------`
+           ^              |    .-------.
+           |              |`->| aborted |
+           |              |    `-------`
+           |  .------.    |    .---------.
+           `-| failed |<-` `->| timed_out |-.
+           |  `------`         `---------`  |
+           `-------------------------------`
+    ```
+
+    Files *may* be requeued by the user in the `failed` or `timed_out`
+    states.
+
+    @type {function}
+   */
+  flush() {
+    let fileQueue = get(this, 'fileQueue');
+
+    if (fileQueue) {
+      fileQueue.flush();
+    }
+
+    let files = get(this, 'files');
+
+    if (files.length === 0) { return; }
+
+    let allFilesHaveSettled = files.every((file) => {
+      return ['uploaded', 'aborted'].includes(file.state);
+    });
+
+    if (allFilesHaveSettled) {
+      get(this, 'files').forEach((file) => set(file, 'queue', null));
+      set(this, 'files', A());
+    }
+  },
+
+  /**
+    The total size of all files currently being uploaded in bytes.
+
+    @computed size
+    @type Number
+    @default 0
+    @readonly
+   */
+  size: sumBy('files', 'size'),
+
+  /**
+    The number of bytes that have been uploaded to the server.
+
+    @computed loaded
+    @type Number
+    @default 0
+    @readonly
+   */
+  loaded: sumBy('files', 'loaded'),
+
+  /**
+    The current progress of all uploads, as a percentage in the
+    range of 0 to 100.
+
+    @computed progress
+    @type Number
+    @default 0
+    @readonly
+   */
+  progress: computed('size', 'loaded', {
+    get() {
+      let percent = get(this, 'loaded') / get(this, 'size') || 0;
+      return Math.floor(percent * 100);
+    }
+  })
+});

--- a/tests/unit/services/file-queue-test.js
+++ b/tests/unit/services/file-queue-test.js
@@ -139,9 +139,13 @@ module('service:file-queue', function(hooks) {
     assert.equal(get(queue, 'files.length'), 3);
 
     queue1.set('files.0.state', 'aborted');
+    queue1.flush();
+
     assert.equal(get(queue, 'files.length'), 3);
 
     queue1.set('files.1.state', 'uploaded');
+    queue1.flush();
+
     assert.equal(get(queue, 'files.length'), 0);
     assert.equal(get(queue1, 'files.length'), 0);
   });


### PR DESCRIPTION
Had a go at this re: #238.

Up to you folks whether this is better than keeping an Observer.

In this implementation I first extracted some duplicate code into a Mixin. I know Mixins are EOL too, but I think they are still better than duplicate code for now.

I then replaced the `flushFilesWhenSettled` observer with a plain function called `flush`.

Note: The FileQueue service tracks files accross all queues. The Queue class tracks its own files.

We only need to call `flush()` on the Queue class. It will check if it is has a `FileQueue` service and call `flush()` on it.

The only places where files have their `state` property changed is in the `upload()` function within the File class, and in the FileQueue service test.