### PR TITLE
Renamed `upload` test helper to `selectFiles` and dropped support for legacy import at `app/tests/helpers/upload`

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -11,24 +11,24 @@ import { assert } from '@ember/debug';
   ```javascript
     // A single file
     const file = new File([], 'dingus.txt');
-    await upload('.file-upload input', file);
+    await selectFiles('.file-upload input', file);
   ```
 
   ```javascript
     // Multiple files
     const file1 = new File([], 'dingus1.txt');
     const file2 = new File([], 'dingus2.txt');
-    await upload('.file-upload input', file1, file2);
+    await selectFiles('.file-upload input', file1, file2);
   ```
 
   Returns `Promise<void>` which resolves when the application is settled.
 
-  @function upload
+  @function selectFiles
   @param {String} selector DOM selector for a FileUpload input
   @param {File} ...files One or more File objects
   @return {Promise}
  */
-export async function upload(selector, ...files) {
+export async function selectFiles(selector, ...files) {
   let input = find(selector);
   assert(`Selector '${selector}' is not input element.`, input.tagName === 'INPUT');
   assert(

--- a/test-support/helpers/upload.js
+++ b/test-support/helpers/upload.js
@@ -1,3 +1,0 @@
-// TODO: This file can be removed with next major version bump
-export { upload } from 'ember-file-upload/test-helpers';
-

--- a/tests/acceptance/upload-test.js
+++ b/tests/acceptance/upload-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { visit, findAll } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupApplicationTest } from 'ember-qunit';
-import { upload } from 'ember-file-upload/test-support';
+import { selectFiles } from 'ember-file-upload/test-support';
 
 function getImageBlob() {
   return new Promise((resolve) => {
@@ -20,7 +20,7 @@ module('Acceptance | upload', function(hooks) {
 
     let data = await getImageBlob();
     let photo = new File([data], 'image.png', { type: 'image/png'});
-    await upload('#upload-photo', photo);
+    await selectFiles('#upload-photo', photo);
 
     let uploadedPhoto = this.server.db.photos[0];
     assert.equal(uploadedPhoto.filename, 'image.png');
@@ -36,7 +36,7 @@ module('Acceptance | upload', function(hooks) {
     let photo = await getImageBlob();
     photo.name = 'image.png';
 
-    await upload('#upload-photo', photo);
+    await selectFiles('#upload-photo', photo);
 
     let uploadedPhoto = this.server.db.photos[0];
     assert.equal(uploadedPhoto.filename, 'image.png');

--- a/tests/dummy/app/templates/docs/testing.md
+++ b/tests/dummy/app/templates/docs/testing.md
@@ -1,9 +1,9 @@
 # Acceptance Tests
 
-`ember-file-upload` provides an `upload` helper for acceptance and integration tests:
+`ember-file-upload` provides a `selectFiles` helper for acceptance and integration tests:
 
 ```javascript
-import { upload } from 'ember-file-upload/test-support';
+import { selectFiles } from 'ember-file-upload/test-support';
 import { module } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 
@@ -12,7 +12,7 @@ module('/notes', function(hooks) {
 
   test('showing a note', async function (assert) {
     let file = new File(['I can feel the money leaving my body'], 'douglas_coupland.txt', { type: 'text/plain' });
-    await upload('#upload-note', file, 'douglas_coupland.txt');
+    await selectFiles('#upload-note', file, 'douglas_coupland.txt');
 
     assert.dom('.note').hasText('I can feel the money leaving my body');
   });
@@ -39,7 +39,7 @@ export default function () {
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { upload } from 'ember-file-upload/test-support';
+import { selectFiles } from 'ember-file-upload/test-support';
 
 module('/photos', function(hooks) {
   setupApplicationTest(hooks);
@@ -54,7 +54,7 @@ module('/photos', function(hooks) {
       78,68,174,66,96,130
     ]);
     let file = new File(data, 'smile.png', { type: 'image/png' });
-    await upload('#upload-photo', file, 'smile.png');
+    await selectFiles('#upload-photo', file, 'smile.png');
 
     let photo = server.db.photos[0];
     assert.equal(photo.filename, 'smile.png');

--- a/tests/integration/components/file-upload-test.js
+++ b/tests/integration/components/file-upload-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, setupOnerror, resetOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { upload } from 'ember-file-upload/test-support';
+import { selectFiles } from 'ember-file-upload/test-support';
 
 module('Integration | Component | FileUpload', function(hooks) {
   setupRenderingTest(hooks);
@@ -12,7 +12,7 @@ module('Integration | Component | FileUpload', function(hooks) {
 
     await render(hbs`<FileUpload @name="test" @onfileadd={{action this.onFileAdd}} />`);
 
-    await upload('input[type="file"]', new File([], 'dingus.txt'));
+    await selectFiles('input[type="file"]', new File([], 'dingus.txt'));
 
     assert.verifySteps(['dingus.txt']);
   });
@@ -22,7 +22,7 @@ module('Integration | Component | FileUpload', function(hooks) {
 
     await render(hbs`<FileUpload @name="test" @onfileadd={{action this.onFileAdd}} />`);
 
-    await upload(
+    await selectFiles(
       'input[type="file"]',
       new File([], 'dingus.txt'),
       new File([], 'dingus.png')

--- a/tests/integration/components/mirage-handler-test.js
+++ b/tests/integration/components/mirage-handler-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, resetOnerror, setupOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { upload as uploadHandler } from 'ember-file-upload/mirage';
-import { upload } from 'ember-file-upload/test-support';
+import { selectFiles } from 'ember-file-upload/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | mirage-handler', function(hooks) {
@@ -49,7 +49,7 @@ module('Integration | Component | mirage-handler', function(hooks) {
     `);
 
     let file = new File(['some-data'], 'text.txt', { type: 'text/plain' });
-    await upload('input', file);
+    await selectFiles('input', file);
 
     assert.verifySteps(['mirage-handler']);
   });
@@ -96,7 +96,7 @@ module('Integration | Component | mirage-handler', function(hooks) {
         {{/file-upload}}
       `);
 
-      await upload('input', file);
+      await selectFiles('input', file);
 
       assert.verifySteps(['error thrown', '500 response']);
     });


### PR DESCRIPTION
Is `test-support/helpers/upload.js` safe to delete?

#306 