### PR TITLE
Improve YUIDoc comments and fix build warnings

### DIFF
--- a/addon/mixins/with-files.js
+++ b/addon/mixins/with-files.js
@@ -25,7 +25,7 @@ export default Mixin.create({
     Files *may* be requeued by the user in the `failed` or `timed_out`
     states.
 
-    @type {function}
+    @method flush
    */
   flush() {
     let fileQueue = get(this, 'fileQueue');

--- a/addon/queue.js
+++ b/addon/queue.js
@@ -54,6 +54,7 @@ export default EmberObject.extend(WithFiles, {
 
   /**
     @private
+    @method _addFiles
     @param {FileList} fileList The event triggered from the DOM that contains a list of files
    */
   _addFiles(fileList, source) {

--- a/addon/services/file-queue.js
+++ b/addon/services/file-queue.js
@@ -20,13 +20,6 @@ import WithFiles from '../mixins/with-files';
  */
 export default Service.extend(WithFiles, {
 
-  /**
-    Setup a map of uploaders so they may be
-    accessed by name via the `find` method.
-
-    @constructor
-   */
-
   init() {
     this._super(...arguments);
     set(this, 'queues', A());


### PR DESCRIPTION
Was seeing a few YUIDoc warnings in my console.

Added missing `@method` tags in `WithFilesMixin` and `Queue`.

Also removed a comment documenting the `init()` method in `FileQueueService`. My reasoning for this is.

- `@constructor` tag is meant to be used in a class block only - it's invalid YUIDoc
- If I tag this code block with `@method` then the `init()` method will show up on the docs site
- In my opinion this comment is superfluous