### PR TITLE
Renamed all events to be camelCase

### DIFF
--- a/addon/components/base-component.js
+++ b/addon/components/base-component.js
@@ -14,7 +14,7 @@ export default Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
     if (get(this, 'queue')) {
-      setProperties(get(this, 'queue'), getProperties(this, 'accept', 'multiple', 'disabled', 'onfileadd'));
+      setProperties(get(this, 'queue'), getProperties(this, 'accept', 'multiple', 'disabled', 'onFileAdd'));
     }
   },
 

--- a/addon/components/file-dropzone/component.js
+++ b/addon/components/file-dropzone/component.js
@@ -42,7 +42,7 @@ const dragListener = new DragListener();
         {{#file-upload name="photos"
                       accept="image/*"
                       multiple=true
-                      onfileadd=(action "uploadImage")}}
+                      onFileAdd=(action "uploadImage")}}
           <a id="upload-image" tabindex=0>Add an Image.</a>
         {{/file-upload}}
       </p>
@@ -114,42 +114,42 @@ export default BaseComponent.extend({
   accept: null,
 
   /**
-    `onfileadd` is called when a file is selected.
+    `onFileAdd` is called when a file is selected.
 
     When multiple files are selected, this function
     is called once for every file that was selected.
 
-    @argument onfileadd
+    @argument onFileAdd
     @type {function}
     @required
    */
-  onfileadd: null,
+  onFileAdd: null,
 
   /**
-    `ondragenter` is called when a file has entered
+    `onDragEnter` is called when a file has entered
     the dropzone.
 
-    @argument ondragenter
+    @argument onDragEnter
     @type {function}
    */
-  ondragenter: null,
+  onDragEnter: null,
 
   /**
-    `ondragleave` is called when a file has left
+    `onDragLeave` is called when a file has left
     the dropzone.
 
-    @argument ondragleave
+    @argument onDragLeave
     @type {function}
    */
-  ondragleave: null,
+  onDragLeave: null,
 
   /**
-    `ondrop` is called when a file has been dropped.
+    `onDrop` is called when a file has been dropped.
 
-    @argument ondrop
+    @argument onDrop
     @type {function}
    */
-  ondrop: null,
+  onDrop: null,
 
   /**
     Whether users can upload content
@@ -219,8 +219,8 @@ export default BaseComponent.extend({
       set(this, 'active', true);
       set(this, 'valid', get(dataTransfer, 'valid'));
 
-      if (this.ondragenter) {
-        this.ondragenter(dataTransfer);
+      if (this.onDragEnter) {
+        this.onDragEnter(dataTransfer);
       }
     }
   },
@@ -231,8 +231,8 @@ export default BaseComponent.extend({
       if (evt.dataTransfer) {
         evt.dataTransfer.dropEffect = get(this, 'cursor');
       }
-      if (this.ondragleave) {
-        this.ondragleave(this[DATA_TRANSFER]);
+      if (this.onDragLeave) {
+        this.onDragLeave(this[DATA_TRANSFER]);
         this[DATA_TRANSFER] = null;
       }
 
@@ -315,8 +315,8 @@ export default BaseComponent.extend({
       image.src = url;
     }
 
-    if (this.ondrop) {
-      this.ondrop(this[DATA_TRANSFER]);
+    if (this.onDrop) {
+      this.onDrop(this[DATA_TRANSFER]);
     }
 
     // Add file(s) to upload queue.

--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -31,7 +31,7 @@ import uuid from '../../system/uuid';
 
       {{#file-upload name="avatar"
                      accept="image/*"
-                     onfileadd=(action 'setAvatar' changeset)}}
+                     onFileAdd=(action 'setAvatar' changeset)}}
         {{#if changeset.avatar}}
           <img src={{changeset.avatar.url}} />
           <a id="upload-avatar" tabindex=0>Add a photo of yourself</a>
@@ -119,16 +119,16 @@ const component = BaseComponent.extend({
   accept: null,
 
   /**
-    `onfileadd` is called when a file is selected.
+    `onFileAdd` is called when a file is selected.
 
     When multiple files are selected, this function
     is called once for every file that was selected.
 
-    @argument onfileadd
+    @argument onFileAdd
     @type {function}
     @required
    */
-  onfileadd: null,
+  onFileAdd: null,
 
   for: computed({
     get() {

--- a/addon/queue.js
+++ b/addon/queue.js
@@ -57,7 +57,7 @@ export default EmberObject.extend(WithFiles, {
     @param {FileList} fileList The event triggered from the DOM that contains a list of files
    */
   _addFiles(fileList, source) {
-    let onfileadd = get(this, 'onfileadd');
+    let onFileAdd = get(this, 'onFileAdd');
     let disabled = get(this, 'disabled');
     let files = [];
 
@@ -70,8 +70,8 @@ export default EmberObject.extend(WithFiles, {
           files.push(file);
           this.push(file);
 
-          if (onfileadd) {
-            next(onfileadd, file);
+          if (onFileAdd) {
+            next(onFileAdd, file);
           }
         }
       }

--- a/tests/dummy/app/templates/docs/recipes.md
+++ b/tests/dummy/app/templates/docs/recipes.md
@@ -24,7 +24,7 @@ For example, creating an image uploader that uploads images to your API server w
                   @for="upload-photo"
                   @accept="image/*"
                   @multiple={{true}}
-                  @onfileadd={{action this.uploadImage}}>
+                  @onFileAdd={{action this.uploadImage}}>
         <a tabindex=0>Add an Image.</a>
       </FileUpload>
     </p>
@@ -36,7 +36,7 @@ It is also possible for you to create a simple file upload button which yields t
 ```handlebars
 <FileUpload @name="photos"
             @accept="image/*"
-            @onfileadd={{action this.uploadImage}} as |queue|>
+            @onFileAdd={{action this.uploadImage}} as |queue|>
   <a class="button">
     {{#if queue.files.length}}
       Uploading...

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -44,7 +44,7 @@
               name="photos"
               for="upload-photo"
               multiple=true
-              onfileadd=(action "uploadProof")
+              onFileAdd=(action "uploadProof")
               accept="image/*,video/*,audio/*"
             }}
               <a>select them</a>

--- a/tests/integration/components/file-dropzone-test.js
+++ b/tests/integration/components/file-dropzone-test.js
@@ -7,7 +7,7 @@ import { dragAndDrop, dragEnter, dragLeave } from 'ember-file-upload/test-suppor
 module('Integration | Component | FileDropzone', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('dropping a file calls ondrop', async function(assert) {
+  test('dropping a file calls onDrop', async function(assert) {
     this.onDrop = (dataTransfer) => {
       dataTransfer.get('files').forEach((file) => assert.step(file.name));
     };
@@ -16,7 +16,7 @@ module('Integration | Component | FileDropzone', function(hooks) {
       <FileDropzone
         class="test-dropzone"
         @name="test"
-        @ondrop={{action this.onDrop}} />
+        @onDrop={{action this.onDrop}} />
     `);
 
     await dragAndDrop('.test-dropzone', new File([], 'dingus.txt'));
@@ -24,7 +24,7 @@ module('Integration | Component | FileDropzone', function(hooks) {
     assert.verifySteps(['dingus.txt']);
   });
 
-  test('dropping multiple files calls ondrop with one file', async function(assert) {
+  test('dropping multiple files calls onDrop with one file', async function(assert) {
     this.onDrop = (dataTransfer) => {
       dataTransfer.get('files').forEach((file) => assert.step(file.name));
     };
@@ -33,7 +33,7 @@ module('Integration | Component | FileDropzone', function(hooks) {
       <FileDropzone
         class="test-dropzone"
         @name="test"
-        @ondrop={{action this.onDrop}} />
+        @onDrop={{action this.onDrop}} />
     `);
 
     await dragAndDrop(
@@ -45,7 +45,7 @@ module('Integration | Component | FileDropzone', function(hooks) {
     assert.verifySteps(['dingus.txt']);
   });
 
-  test('multiple=true dropping multiple files calls ondrop with both files', async function(assert) {
+  test('multiple=true dropping multiple files calls onDrop with both files', async function(assert) {
     this.onDrop = (dataTransfer) => {
       dataTransfer.get('files').forEach((file) => assert.step(file.name));
     };
@@ -55,7 +55,7 @@ module('Integration | Component | FileDropzone', function(hooks) {
         class="test-dropzone"
         @name="test"
         @multiple={{true}}
-        @ondrop={{action this.onDrop}} />
+        @onDrop={{action this.onDrop}} />
     `);
 
     await dragAndDrop(
@@ -67,14 +67,14 @@ module('Integration | Component | FileDropzone', function(hooks) {
     assert.verifySteps(['dingus.txt', 'dingus.png']);
   });
 
-  test('ondragenter is called when a file is dragged over', async function(assert) {
+  test('onDragEnter is called when a file is dragged over', async function(assert) {
     this.onDragEnter = () => assert.step('onDragEnter');
 
     await render(hbs`
       <FileDropzone
         class="test-dropzone"
         @name="test"
-        @ondragenter={{action this.onDragEnter}} />
+        @onDragEnter={{action this.onDragEnter}} />
     `);
 
     await dragEnter('.test-dropzone');
@@ -82,14 +82,14 @@ module('Integration | Component | FileDropzone', function(hooks) {
     assert.verifySteps(['onDragEnter']);
   });
 
-  test('ondragleave is called when a file is dragged out', async function(assert) {
+  test('onDragLeave is called when a file is dragged out', async function(assert) {
     this.onDragLeave = () => assert.step('onDragLeave');
 
     await render(hbs`
       <FileDropzone
         class="test-dropzone"
         @name="test"
-        @ondragleave={{action this.onDragLeave}} />
+        @onDragLeave={{action this.onDragLeave}} />
     `);
 
     await dragEnter('.test-dropzone', new File([], 'dingus.txt'));

--- a/tests/integration/components/file-upload-test.js
+++ b/tests/integration/components/file-upload-test.js
@@ -7,10 +7,10 @@ import { selectFiles } from 'ember-file-upload/test-support';
 module('Integration | Component | FileUpload', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('uploading a file calls onfileadd', async function(assert) {
+  test('uploading a file calls onFileAdd', async function(assert) {
     this.onFileAdd = (file) => assert.step(file.get('name'));
 
-    await render(hbs`<FileUpload @name="test" @onfileadd={{action this.onFileAdd}} />`);
+    await render(hbs`<FileUpload @name="test" @onFileAdd={{action this.onFileAdd}} />`);
 
     await selectFiles('input[type="file"]', new File([], 'dingus.txt'));
 
@@ -20,7 +20,7 @@ module('Integration | Component | FileUpload', function(hooks) {
   test('uploading multiple files calls onfileadd multiple times', async function(assert) {
     this.onFileAdd = (file) => assert.step(file.get('name'));
 
-    await render(hbs`<FileUpload @name="test" @onfileadd={{action this.onFileAdd}} />`);
+    await render(hbs`<FileUpload @name="test" @onFileAdd={{action this.onFileAdd}} />`);
 
     await selectFiles(
       'input[type="file"]',

--- a/tests/integration/components/mirage-handler-test.js
+++ b/tests/integration/components/mirage-handler-test.js
@@ -40,7 +40,7 @@ module('Integration | Component | mirage-handler', function(hooks) {
     await render(hbs`
       {{#file-upload
         name="file"
-        onfileadd=uploadImage
+        onFileAdd=uploadImage
       }}
         <a class="button">
           Upload file
@@ -88,7 +88,7 @@ module('Integration | Component | mirage-handler', function(hooks) {
       await render(hbs`
         {{#file-upload
           name="file"
-          onfileadd=uploadImage
+          onFileAdd=uploadImage
         }}
           <a class="button">
             Upload file


### PR DESCRIPTION
This is a breaking change to the public API to bring event names more in line with convention.

Requested in #284 

As @jelhan mentioned, we could use [deprecatingAlias](https://api.emberjs.com/ember/3.13/functions/@ember%2Fobject%2Fcomputed/deprecatingAlias) to support both names for a time.