### PR TITLE
Add edge to build targets for docs app

### DIFF
--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -3,7 +3,8 @@
 const browsers = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',
-  'last 1 Safari versions'
+  'last 1 Safari versions',
+  'last 1 edge versions'
 ];
 
 module.exports = {


### PR DESCRIPTION
See #332 

Add `last 1 edge versions` to dummy app targets so that generated code is compatible with Microsoft Edge.

Before
![ember-file-upload-edge](https://user-images.githubusercontent.com/56396753/76643727-ecf00580-6555-11ea-87c1-4fc53dfa7b53.jpg)

After
<img width="1259" alt="Capture d’écran 2020-03-13 à 17 44 54" src="https://user-images.githubusercontent.com/56396753/76643708-e497ca80-6555-11ea-8871-1e561a55b335.png">

