### PR TITLE
build targets should cover a wider browser range

### DIFF
--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,10 +1,14 @@
 'use strict';
 
 const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions',
-  'last 1 edge versions'
+  'last 2 Chrome versions',
+  'last 2 Firefox versions',
+  'Firefox ESR',
+  'last 2 Safari versions',
+  // Last versions of Microsoft Edge are build on top of Chromium. But they are
+  // not shipped yet to a significant number of users. Need to still support
+  // Edge 18 explicitly until chromium-based Edge is shipped to all users.
+  'Edge >= 18'
 ];
 
 module.exports = {


### PR DESCRIPTION
This also fixes the syntax error in common Edge versions.

All credits to @simonihmig who [pointed me in the correct direction](https://github.com/kaliber5/ember-bootstrap/issues/1027#issuecomment-612390042).

Closes #332 