### PR TITLE
floating dependency scenario must ignore lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,14 @@ jobs:
 
     - stage: "Tests"
       name: "Tests"
-      install:
-        - yarn install --non-interactive
       script:
         - yarn lint:hbs
         - yarn lint:js
         - yarn test
 
     - name: "Floating Dependencies"
+      install:
+        - yarn install --no-lockfile --non-interactive
       script:
         - yarn test
 


### PR DESCRIPTION
While working on #353 I noticed that the *floating dependencies* scenario was not testing what it claimed to test. It installed the locked versions of dependencies as any other test.

[This](https://travis-ci.org/github/adopted-ember-addons/ember-file-upload/jobs/711901361#L517) is an example of recent run of that scenario which shows that the dependencies are installed with `yarn install --frozen-lockfile --non-interactive`. Instead of `--frozen-lockfile` the `--no-lockfile` flag must be present for this scenario.

This PR fixes it. It changes the Travis CI configuration to be more inline with the [latest blueprint version](https://github.com/ember-cli/ember-cli/blob/afb31dd97b3d03f428ba919b049e9ac5ac9807d8/blueprints/addon/files/.travis.yml#L46-L48).