### PR TITLE
docs: add link to accept argument docs

### DIFF
--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -112,7 +112,7 @@ const component = BaseComponent.extend({
 
 
   /**
-    A list of MIME types / extensions to be accepted by the input
+    A comma-separated list of MIME types / extensions to be accepted by the input, as documented here https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept
     @argument accept
     @type {string}
    */


### PR DESCRIPTION
Just to clarify so users don't have to search the code to see how it should be formatted