### PR TITLE
Drop support for Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "10"
+  - "12"
 
 dist: xenial
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Uploads continue in the background, even after a page transition. In other words
 
 * Ember.js v3.16 or above
 * Ember CLI v2.13 or above
-* Node.js v10 or above
+* Node.js v12 or above
 * Modern browsers. Internet Explorer 11 might work but is not offically supported.
 * Strict Content Security Policy (CSP) except for mirage route handlers, which require `data:` protocol to be included in `image-src` and `media-src` directives.
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "sass": "^1.32.10"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "12.* || >= 14.*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Required by #459 and #447

@jelhan considering this already approved by you:

> > This upgrade would also require us to drop node 10.
> 
> Let's do. We already merged breaking changes. So would be a good time to drop node 10 as well.

