### PR TITLE
Ignore progress events where the total file size is reported as 0 bytes

### DIFF
--- a/addon/file.js
+++ b/addon/file.js
@@ -74,11 +74,11 @@ function upload(file, url, opts, uploadFn) {
   }
 
   request.onprogress = function (evt) {
-    if (evt.lengthComputable) {
-      set(file, 'loaded', evt.loaded);
-      set(file, 'size', evt.total);
-      set(file, 'progress', (evt.loaded / evt.total) * 100);
-    }
+    if (!evt.lengthComputable || evt.total === 0) return;
+
+    set(file, 'loaded', evt.loaded);
+    set(file, 'size', evt.total);
+    set(file, 'progress', (evt.loaded / evt.total) * 100);
   };
 
   request.ontimeout = function () {


### PR DESCRIPTION
Have tested this manually using the docs site. Wasn't able to reproduce a `NaN` value.

### Before

- Drop a file
- Progresses from 0 => 100%
- Progress set back to 0% for a moment
- Finishes

### After

- Drop a file
- Progresses from 0 => 100%
- Progress stays at 100% for a moment
- Finishes

Fixes #344