### PR TITLE
Renamed all events to camelCase

### DIFF
--- a/addon/components/base-component.js
+++ b/addon/components/base-component.js
@@ -9,8 +9,8 @@ export default Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
     if (this.queue) {
-      let { accept, multiple, disabled, onfileadd } = this;
-      setProperties(this.queue, { accept, multiple, disabled, onfileadd });
+      let { accept, multiple, disabled, onFileAdd } = this;
+      setProperties(this.queue, { accept, multiple, disabled, onFileAdd });
     }
   },
 

--- a/addon/components/file-dropzone/component.js
+++ b/addon/components/file-dropzone/component.js
@@ -2,6 +2,7 @@ import BaseComponent from '../base-component';
 
 import { bind } from '@ember/runloop';
 import { set } from '@ember/object';
+import { deprecatingAlias } from '@ember/object/computed';
 import { getOwner } from '@ember/application';
 import layout from './template';
 import DataTransfer from '../../system/data-transfer';
@@ -44,7 +45,7 @@ const dragListener = new DragListener();
         {{#file-upload name="photos"
                       accept="image/*"
                       multiple=true
-                      onfileadd=(action "uploadImage")}}
+                      onFileAdd=(action "uploadImage")}}
           <a id="upload-image" tabindex=0>Add an Image.</a>
         {{/file-upload}}
       </p>
@@ -114,42 +115,58 @@ export default BaseComponent.extend({
   accept: null,
 
   /**
-    `onfileadd` is called when a file is selected.
+    `onFileAdd` is called when a file is selected.
 
     When multiple files are selected, this function
     is called once for every file that was selected.
 
-    @argument onfileadd
+    @argument onFileAdd
     @type {function}
     @required
    */
-  onfileadd: null,
+  onFileAdd: null,
+  onfileadd: deprecatingAlias('onFileAdd', {
+    id: 'ember-file-upload.deprecate-non-camel-case-events',
+    until: '5.0.0',
+  }),
 
   /**
-    `ondragenter` is called when a file has entered
+    `onDragEnter` is called when a file has entered
     the dropzone.
 
-    @argument ondragenter
+    @argument onDragEnter
     @type {function}
    */
-  ondragenter: null,
+  onDragEnter: null,
+  ondragenter: deprecatingAlias('onDragEnter', {
+    id: 'ember-file-upload.deprecate-non-camel-case-events',
+    until: '5.0.0',
+  }),
 
   /**
-    `ondragleave` is called when a file has left
+    `onDragLeave` is called when a file has left
     the dropzone.
 
-    @argument ondragleave
+    @argument onDragLeave
     @type {function}
    */
-  ondragleave: null,
+  onDragLeave: null,
+  ondragleave: deprecatingAlias('onDragLeave', {
+    id: 'ember-file-upload.deprecate-non-camel-case-events',
+    until: '5.0.0',
+  }),
 
   /**
-    `ondrop` is called when a file has been dropped.
+    `onDrop` is called when a file has been dropped.
 
-    @argument ondrop
+    @argument onDrop
     @type {function}
    */
-  ondrop: null,
+  onDrop: null,
+  ondrop: deprecatingAlias('onDrop', {
+    id: 'ember-file-upload.deprecate-non-camel-case-events',
+    until: '5.0.0',
+  }),
 
   /**
     Whether users can upload content
@@ -223,8 +240,8 @@ export default BaseComponent.extend({
       set(this, 'active', true);
       set(this, 'valid', dataTransfer.valid);
 
-      if (this.ondragenter) {
-        this.ondragenter(dataTransfer);
+      if (this.onDragEnter) {
+        this.onDragEnter(dataTransfer);
       }
     }
   },
@@ -235,8 +252,8 @@ export default BaseComponent.extend({
       if (evt.dataTransfer) {
         evt.dataTransfer.dropEffect = this.cursor;
       }
-      if (this.ondragleave) {
-        this.ondragleave(this[DATA_TRANSFER]);
+      if (this.onDragLeave) {
+        this.onDragLeave(this[DATA_TRANSFER]);
         this[DATA_TRANSFER] = null;
       }
 
@@ -319,8 +336,8 @@ export default BaseComponent.extend({
       image.src = url;
     }
 
-    if (this.ondrop) {
-      this.ondrop(this[DATA_TRANSFER]);
+    if (this.onDrop) {
+      this.onDrop(this[DATA_TRANSFER]);
     }
 
     // Add file(s) to upload queue.

--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -2,6 +2,7 @@ import { assert } from '@ember/debug';
 import BaseComponent from '../base-component';
 import { DEBUG } from '@glimmer/env';
 import { computed } from '@ember/object';
+import { deprecatingAlias } from '@ember/object/computed';
 import layout from './template';
 import uuid from '../../system/uuid';
 
@@ -28,7 +29,7 @@ import uuid from '../../system/uuid';
 
       {{#file-upload name="avatar"
                      accept="image/*"
-                     onfileadd=(action 'setAvatar' changeset)}}
+                     onFileAdd=(action 'setAvatar' changeset)}}
         {{#if changeset.avatar}}
           <img src={{changeset.avatar.url}} />
           <a id="upload-avatar" tabindex=0>Add a photo of yourself</a>
@@ -115,16 +116,20 @@ const component = BaseComponent.extend({
   accept: null,
 
   /**
-    `onfileadd` is called when a file is selected.
+    `onFileAdd` is called when a file is selected.
 
     When multiple files are selected, this function
     is called once for every file that was selected.
 
-    @argument onfileadd
+    @argument onFileAdd
     @type {function}
     @required
    */
-  onfileadd: null,
+  onFileAdd: null,
+  onfileadd: deprecatingAlias('onFileAdd', {
+    id: 'ember-file-upload.deprecate-non-camel-case-events',
+    until: '5.0.0',
+  }),
 
   for: computed({
     get() {

--- a/addon/queue.js
+++ b/addon/queue.js
@@ -53,7 +53,7 @@ export default EmberObject.extend(WithFiles, {
     @param {FileList} fileList The event triggered from the DOM that contains a list of files
    */
   _addFiles(fileList, source) {
-    let onfileadd = this.onfileadd;
+    let onFileAdd = this.onFileAdd;
     let disabled = this.disabled;
     let files = [];
 
@@ -66,8 +66,8 @@ export default EmberObject.extend(WithFiles, {
           files.push(file);
           this.push(file);
 
-          if (onfileadd) {
-            next(onfileadd, file);
+          if (onFileAdd) {
+            next(onFileAdd, file);
           }
         }
       }

--- a/tests/dummy/app/components/demo-upload.hbs
+++ b/tests/dummy/app/components/demo-upload.hbs
@@ -20,7 +20,7 @@
         {{#if dropzone.supported}}
           Drag your proof or
         {{/if}}
-        <FileUpload @name="photos" @for="upload-photo" @multiple={{true}} @onfileadd={{this.uploadProof}} @accept="image/*,video/*,audio/*">
+        <FileUpload @name="photos" @for="upload-photo" @multiple={{true}} @onFileAdd={{this.uploadProof}} @accept="image/*,video/*,audio/*">
           <a {{!template-lint-disable link-href-attributes}}>select them</a>
         </FileUpload>
         to upload.

--- a/tests/dummy/app/templates/docs/recipes.md
+++ b/tests/dummy/app/templates/docs/recipes.md
@@ -24,7 +24,7 @@ For example, creating an image uploader that uploads images to your API server w
                   @for="upload-photo"
                   @accept="image/*"
                   @multiple={{true}}
-                  @onfileadd={{action this.uploadImage}}>
+                  @onFileAdd={{action this.uploadImage}}>
         <a tabindex=0>Add an Image.</a>
       </FileUpload>
     </p>
@@ -36,7 +36,7 @@ It is also possible for you to create a simple file upload button which yields t
 ```handlebars
 <FileUpload @name="photos"
             @accept="image/*"
-            @onfileadd={{action this.uploadImage}} as |queue|>
+            @onFileAdd={{action this.uploadImage}} as |queue|>
   <a class="button">
     {{#if queue.files.length}}
       Uploading...

--- a/tests/integration/components/file-dropzone-test.js
+++ b/tests/integration/components/file-dropzone-test.js
@@ -11,7 +11,7 @@ import {
 module('Integration | Component | FileDropzone', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('dropping a file calls ondrop', async function (assert) {
+  test('dropping a file calls onDrop', async function (assert) {
     this.onDrop = (dataTransfer) => {
       dataTransfer.get('files').forEach((file) => assert.step(file.name));
     };
@@ -20,7 +20,7 @@ module('Integration | Component | FileDropzone', function (hooks) {
       <FileDropzone
         class="test-dropzone"
         @name="test"
-        @ondrop={{action this.onDrop}} />
+        @onDrop={{this.onDrop}} />
     `);
 
     await dragAndDrop('.test-dropzone', new File([], 'dingus.txt'));
@@ -28,7 +28,7 @@ module('Integration | Component | FileDropzone', function (hooks) {
     assert.verifySteps(['dingus.txt']);
   });
 
-  test('dropping multiple files calls ondrop with one file', async function (assert) {
+  test('deprecated: dropping a file calls ondrop', async function (assert) {
     this.onDrop = (dataTransfer) => {
       dataTransfer.get('files').forEach((file) => assert.step(file.name));
     };
@@ -37,7 +37,24 @@ module('Integration | Component | FileDropzone', function (hooks) {
       <FileDropzone
         class="test-dropzone"
         @name="test"
-        @ondrop={{action this.onDrop}} />
+        @ondrop={{this.onDrop}} />
+    `);
+
+    await dragAndDrop('.test-dropzone', new File([], 'dingus.txt'));
+
+    assert.verifySteps(['dingus.txt']);
+  });
+
+  test('dropping multiple files calls onDrop with one file', async function (assert) {
+    this.onDrop = (dataTransfer) => {
+      dataTransfer.get('files').forEach((file) => assert.step(file.name));
+    };
+
+    await render(hbs`
+      <FileDropzone
+        class="test-dropzone"
+        @name="test"
+        @onDrop={{this.onDrop}} />
     `);
 
     await dragAndDrop(
@@ -49,7 +66,28 @@ module('Integration | Component | FileDropzone', function (hooks) {
     assert.verifySteps(['dingus.txt']);
   });
 
-  test('multiple=true dropping multiple files calls ondrop with both files', async function (assert) {
+  test('deprecated: dropping multiple files calls ondrop with one file', async function (assert) {
+    this.onDrop = (dataTransfer) => {
+      dataTransfer.get('files').forEach((file) => assert.step(file.name));
+    };
+
+    await render(hbs`
+      <FileDropzone
+        class="test-dropzone"
+        @name="test"
+        @ondrop={{this.onDrop}} />
+    `);
+
+    await dragAndDrop(
+      '.test-dropzone',
+      new File([], 'dingus.txt'),
+      new File([], 'dingus.png')
+    );
+
+    assert.verifySteps(['dingus.txt']);
+  });
+
+  test('multiple=true dropping multiple files calls onDrop with both files', async function (assert) {
     this.onDrop = (dataTransfer) => {
       dataTransfer.get('files').forEach((file) => assert.step(file.name));
     };
@@ -59,7 +97,7 @@ module('Integration | Component | FileDropzone', function (hooks) {
         class="test-dropzone"
         @name="test"
         @multiple={{true}}
-        @ondrop={{action this.onDrop}} />
+        @onDrop={{this.onDrop}} />
     `);
 
     await dragAndDrop(
@@ -71,14 +109,36 @@ module('Integration | Component | FileDropzone', function (hooks) {
     assert.verifySteps(['dingus.txt', 'dingus.png']);
   });
 
-  test('ondragenter is called when a file is dragged over', async function (assert) {
+  test('deprecated: multiple=true dropping multiple files calls ondrop with both files', async function (assert) {
+    this.onDrop = (dataTransfer) => {
+      dataTransfer.get('files').forEach((file) => assert.step(file.name));
+    };
+
+    await render(hbs`
+      <FileDropzone
+        class="test-dropzone"
+        @name="test"
+        @multiple={{true}}
+        @ondrop={{this.onDrop}} />
+    `);
+
+    await dragAndDrop(
+      '.test-dropzone',
+      new File([], 'dingus.txt'),
+      new File([], 'dingus.png')
+    );
+
+    assert.verifySteps(['dingus.txt', 'dingus.png']);
+  });
+
+  test('onDragEnter is called when a file is dragged over', async function (assert) {
     this.onDragEnter = () => assert.step('onDragEnter');
 
     await render(hbs`
       <FileDropzone
         class="test-dropzone"
         @name="test"
-        @ondragenter={{action this.onDragEnter}} />
+        @onDragEnter={{this.onDragEnter}} />
     `);
 
     await dragEnter('.test-dropzone');
@@ -86,14 +146,45 @@ module('Integration | Component | FileDropzone', function (hooks) {
     assert.verifySteps(['onDragEnter']);
   });
 
-  test('ondragleave is called when a file is dragged out', async function (assert) {
+  test('deprecated: ondragenter is called when a file is dragged over', async function (assert) {
+    this.onDragEnter = () => assert.step('onDragEnter');
+
+    await render(hbs`
+      <FileDropzone
+        class="test-dropzone"
+        @name="test"
+        @ondragenter={{this.onDragEnter}} />
+    `);
+
+    await dragEnter('.test-dropzone');
+
+    assert.verifySteps(['onDragEnter']);
+  });
+
+  test('onDragLeave is called when a file is dragged out', async function (assert) {
     this.onDragLeave = () => assert.step('onDragLeave');
 
     await render(hbs`
       <FileDropzone
         class="test-dropzone"
         @name="test"
-        @ondragleave={{action this.onDragLeave}} />
+        @onDragLeave={{this.onDragLeave}} />
+    `);
+
+    await dragEnter('.test-dropzone', new File([], 'dingus.txt'));
+    await dragLeave('.test-dropzone', new File([], 'dingus.txt'));
+
+    assert.verifySteps(['onDragLeave']);
+  });
+
+  test('deprecated: ondragleave is called when a file is dragged out', async function (assert) {
+    this.onDragLeave = () => assert.step('onDragLeave');
+
+    await render(hbs`
+      <FileDropzone
+        class="test-dropzone"
+        @name="test"
+        @ondragleave={{this.onDragLeave}} />
     `);
 
     await dragEnter('.test-dropzone', new File([], 'dingus.txt'));

--- a/tests/integration/components/file-upload-test.js
+++ b/tests/integration/components/file-upload-test.js
@@ -7,11 +7,11 @@ import { selectFiles } from 'ember-file-upload/test-support';
 module('Integration | Component | FileUpload', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('uploading a file calls onfileadd', async function (assert) {
+  test('uploading a file calls onFileAdd', async function (assert) {
     this.onFileAdd = (file) => assert.step(file.get('name'));
 
     await render(
-      hbs`<FileUpload @name="test" @onfileadd={{action this.onFileAdd}} />`
+      hbs`<FileUpload @name="test" @onFileAdd={{this.onFileAdd}} />`
     );
 
     await selectFiles('input[type="file"]', new File([], 'dingus.txt'));
@@ -19,11 +19,39 @@ module('Integration | Component | FileUpload', function (hooks) {
     assert.verifySteps(['dingus.txt']);
   });
 
-  test('uploading multiple files calls onfileadd multiple times', async function (assert) {
+  test('deprecated: uploading a file calls onfileadd', async function (assert) {
     this.onFileAdd = (file) => assert.step(file.get('name'));
 
     await render(
-      hbs`<FileUpload @name="test" @onfileadd={{action this.onFileAdd}} />`
+      hbs`<FileUpload @name="test" @onfileadd={{this.onFileAdd}} />`
+    );
+
+    await selectFiles('input[type="file"]', new File([], 'dingus.txt'));
+
+    assert.verifySteps(['dingus.txt']);
+  });
+
+  test('uploading multiple files calls onFileAdd multiple times', async function (assert) {
+    this.onFileAdd = (file) => assert.step(file.get('name'));
+
+    await render(
+      hbs`<FileUpload @name="test" @onFileAdd={{this.onFileAdd}} />`
+    );
+
+    await selectFiles(
+      'input[type="file"]',
+      new File([], 'dingus.txt'),
+      new File([], 'dingus.png')
+    );
+
+    assert.verifySteps(['dingus.txt', 'dingus.png']);
+  });
+
+  test('deprecated: uploading multiple files calls onfileadd multiple times', async function (assert) {
+    this.onFileAdd = (file) => assert.step(file.get('name'));
+
+    await render(
+      hbs`<FileUpload @name="test" @onfileadd={{this.onFileAdd}} />`
     );
 
     await selectFiles(

--- a/tests/integration/components/mirage-handler-test.js
+++ b/tests/integration/components/mirage-handler-test.js
@@ -48,14 +48,14 @@ module('Integration | Component | mirage-handler', function (hooks) {
       return file.upload('/folder/1/file');
     });
     await render(hbs`
-      {{#file-upload
-        name="file"
-        onfileadd=uploadImage
-      }}
+      <FileUpload
+        @name="file"
+        @onFileAdd={{this.uploadImage}}
+      >
         <a class="button">
           Upload file
         </a>
-      {{/file-upload}}
+      </FileUpload>
     `);
 
     let file = new File(['some-data'], 'text.txt', { type: 'text/plain' });
@@ -107,15 +107,15 @@ module('Integration | Component | mirage-handler', function (hooks) {
           return file.upload('/image');
         });
         await render(hbs`
-        {{#file-upload
-          name="file"
-          onfileadd=uploadImage
-        }}
-          <a class="button">
-            Upload file
-          </a>
-        {{/file-upload}}
-      `);
+          <FileUpload
+            @name="file"
+            @onFileAdd={{this.uploadImage}}
+          >
+            <a class="button">
+              Upload file
+            </a>
+          </FileUpload>
+        `);
 
         await selectFiles('input', file);
 


### PR DESCRIPTION
Includes `deprecatingAlias` support for old event names until 5.0.0

Added component tests to cover both new and deprecated event names. The duplicated tests are quick and dirty but they will all helpfully fail as soon as the alias is removed.

See #328 for previous discussion