### PR TITLE
Improve copy and layout of doc site index

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -5,18 +5,6 @@ module.exports = {
 
   overrides: [
     {
-      files: [
-        'addon/components/file-dropzone/template.hbs',
-        'addon/components/file-upload/template.hbs',
-        'tests/dummy/app/templates/application.hbs',
-        'tests/dummy/app/templates/index.hbs',
-        'tests/dummy/app/templates/not-found.hbs',
-      ],
-      rules: {
-        'no-curly-component-invocation': false,
-      },
-    },
-    {
       files: ['addon/components/file-upload/template.hbs'],
       rules: {
         'no-action': false,

--- a/tests/dummy/app/components/demo-upload.hbs
+++ b/tests/dummy/app/components/demo-upload.hbs
@@ -1,5 +1,4 @@
-<div class="my-16 text-center">
-  <h1 class="my-8">Demo</h1>
+<div class="my-16 text-center docs-text-white">
   <FileDropzone @name="photos" @class="demo-dropzone" as |dropzone queue|>
     <div class="dropzone-upload-area upload {{if dropzone.active "active"}}">
       {{#if dropzone.supported}}
@@ -18,10 +17,10 @@
 
       <p>
         {{#if dropzone.supported}}
-          Drag your proof or
+          Drag image, video or audio files here or
         {{/if}}
         <FileUpload @name="photos" @for="upload-photo" @multiple={{true}} @onFileAdd={{this.uploadProof}} @accept="image/*,video/*,audio/*">
-          <a {{!template-lint-disable link-href-attributes}}>select them</a>
+          <a {{!template-lint-disable link-href-attributes}}>choose files</a>
         </FileUpload>
         to upload.
       </p>
@@ -34,7 +33,7 @@
 </div>
 <div class="my-16">
   <ul class="demo-uploaded-files-list">
-    {{#each @model as |file|}}
+    {{#each @files as |file|}}
       <li>
         <div class="card text-center">
           {{#if file.file}}

--- a/tests/dummy/app/components/demo-upload.js
+++ b/tests/dummy/app/components/demo-upload.js
@@ -22,7 +22,7 @@ export default class DemoUpload extends Component {
       file,
     });
 
-    this.args.model.pushObject(asset);
+    this.args.files.pushObject(asset);
 
     let response;
     try {

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -6,12 +6,12 @@ export default class IndexRoute extends Route {
     return A([
       {
         filename: 'little-green-men.jpg',
-        preview: '/assets/images/little-green-men.jpg',
+        preview: 'assets/images/little-green-men.jpg',
         type: 'image',
       },
       {
         filename: 'samantha-mulder.jpg',
-        preview: '/assets/images/samantha-mulder.jpg',
+        preview: 'assets/images/samantha-mulder.jpg',
         type: 'image',
       },
     ]);

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,5 +1,8 @@
 .demo-dropzone {
   .dropzone-upload-area {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     border: 4px dotted #BBB;
     border-radius: 10px;
     height: 300px;

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,23 +1,12 @@
-{{docs-hero
-  logo="ember"
-  slimHeading="File"
-  strongHeading="Upload"
-  byline="A file upload framework for Ember apps."
-}}
+<DocsHero
+  @logo="ember"
+  @slimHeading="File"
+  @strongHeading="Upload"
+  @byline="A file upload framework for Ember apps."
+/>
 
 <div class="docs-container docs-md">
-  <section class="max-w-md mx-auto pb-4">
-    <div class="my-16 text-center">
-      {{#link-to
-        route="docs"
-        class="bg-grey-darkest hover:bg-black text-white py-2 px-4 no-underline rounded"
-      }}
-        Get started →
-      {{/link-to}}
-    </div>
-  </section>
-
   <section class="max-w-md mx-auto">
-    <DemoUpload @model={{@model}}/>
+    <DemoUpload @files={{@model}}/>
   </section>
 </div>

--- a/tests/dummy/app/templates/not-found.hbs
+++ b/tests/dummy/app/templates/not-found.hbs
@@ -1,4 +1,4 @@
 <div class="docs-container">
   <h1>Not found</h1>
-  <p>This page doesn't exist. {{#link-to route="index"}}Head home?{{/link-to}}</p>
+  <p>This page doesn't exist. <LinkTo @route="index">Head home?</LinkTo></p>
 </div>

--- a/tests/integration/upload-test.js
+++ b/tests/integration/upload-test.js
@@ -19,8 +19,8 @@ module('Integration | upload', function (hooks) {
   setupMirage(hooks);
 
   test('upload works for File', async function (assert) {
-    this.model = A([]);
-    await render(hbs`<DemoUpload @model={{this.model}}/>`);
+    this.files = A([]);
+    await render(hbs`<DemoUpload @files={{this.files}} />`);
 
     let data = await getImageBlob();
     let photo = new File([data], 'image.png', { type: 'image/png' });
@@ -39,8 +39,8 @@ module('Integration | upload', function (hooks) {
   });
 
   test('upload works for Blob', async function (assert) {
-    this.model = A([]);
-    await render(hbs`<DemoUpload @model={{this.model}}/>`);
+    this.files = A([]);
+    await render(hbs`<DemoUpload @files={{this.files}} />`);
 
     let photo = await getImageBlob();
     photo.name = 'image.png';


### PR DESCRIPTION
Attempt to fix asset paths for demo images.

Migrate remaining curly invocations to angle-bracket.

### Before

![Screen Shot 2021-06-21 at 12 51 04 PM](https://user-images.githubusercontent.com/36919/122693783-716c2080-d28f-11eb-9472-348157af8fa3.png)

### After

![Screen Shot 2021-06-21 at 12 51 12 PM](https://user-images.githubusercontent.com/36919/122693789-74671100-d28f-11eb-9dd8-909b1901838c.png)
