### PR TITLE
Add concurrency to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,7 @@
 name: Deploy
 
+concurrency: deploy
+
 on:
   push:
     branches:


### PR DESCRIPTION
Should cause all deploy jobs to be queued and solve issues with deploys racing each other.

We saw an issue recently when we tagged a release where the `tag` and `master` deploys raced each other, causing the slower deployment to fail.