### PR TITLE
Update docsite homepage after background color change

### DIFF
--- a/tests/dummy/app/components/demo-upload.hbs
+++ b/tests/dummy/app/components/demo-upload.hbs
@@ -1,4 +1,4 @@
-<div class="my-16 text-center docs-text-white">
+<div class="docs-my-8 text-center">
   <FileDropzone @name="photos" @class="demo-dropzone" as |dropzone queue|>
     <div class="dropzone-upload-area upload {{if dropzone.active "active"}}">
       {{#if dropzone.supported}}


### PR DESCRIPTION
Default bg color was changed in ember-learn/ember-cli-addon-docs/pull/747

**Before**

<img width="1027" alt="Screen Shot 2021-09-03 at 1 17 09 PM" src="https://user-images.githubusercontent.com/36919/131935980-8152182f-7afd-4964-9a9f-4eddc29ebc0e.png">

**After**

<img width="1025" alt="Screen Shot 2021-09-03 at 1 17 16 PM" src="https://user-images.githubusercontent.com/36919/131935985-10fc6cd3-ef51-44e8-bcb7-a123d4d593fb.png">
