### PR TITLE
Update docs examples to use Octane syntax

### DIFF
--- a/addon/components/file-dropzone.js
+++ b/addon/components/file-dropzone.js
@@ -129,11 +129,13 @@ let supported = (function () {
         {{#if dropzone.supported}}
           Drag and drop images onto this area to upload them or
         {{/if}}
-        <FileUpload @name="photos"
-                    @accept="image/*"
-                    @multiple=true
-                    @onFileAdd={{this.uploadImage}}>
-          <a id="upload-image" tabindex=0>Add an Image.</a>
+        <FileUpload
+          @name="photos"
+          @accept="image/*"
+          @multiple=true
+          @onFileAdd={{perform this.uploadImage}}
+        >
+          <a tabindex="0">Add an Image.</a>
         </FileUpload>
       </p>
     {{/if}}
@@ -141,20 +143,19 @@ let supported = (function () {
   ```
 
   ```js
-  import Controller from '@ember/controller';
+  import Component from '@glimmer/component';
+  import { task } from 'ember-concurrency';
 
-  export default Ember.Route.extend({
-    actions: {
-      uploadImage(file) {
-       file.upload(URL, options).then((response) => {
-          ...
-       });
-      }
+  export default class ExampleComponent extends Component {
+    @task({ maxConcurrency: 3, enqueue: true })
+    *uploadImage(file) {
+      const response = yield file.upload(url, options);
+      ...
     }
-  });
+  }
   ```
 
-  @class FileDropzone
+  @class FileDropzoneComponent
   @type Ember.Component
   @yield {Hash} dropzone
   @yield {boolean} dropzone.supported

--- a/tests/dummy/app/templates/docs/integration.md
+++ b/tests/dummy/app/templates/docs/integration.md
@@ -1,50 +1,61 @@
 # Integration
 
-The addon emits an event when a file is queued for upload. You may trigger the upload by calling the `upload` function on the file, which returns a promise that is resolved when the file has finished uploading and is rejected if the file couldn't be uploaded.
+The addon calls `onFileAdd` when a file is queued for upload. You may trigger the upload by calling the `upload` function on the file, which returns a promise that is resolved when the file has finished uploading and is rejected if the file couldn't be uploaded.
+
+```hbs
+<FileUpload
+  @name="photos"
+  @accept="image/*"
+  @onFileAdd={{perform this.uploadPhoto}}
+  as |queue|
+>
+  <a tabindex="0">
+    {{#if queue.files.length}}
+      Uploading...
+    {{else}}
+      Upload file
+    {{/if}}
+  </a>
+</FileUpload>
+```
 
 ```javascript
-import Ember from 'ember';
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 
-const { get, set } = Ember;
+export default class ExampleComponent extends Component {
+  @service store;
 
-export default Ember.Route.extend({
-
-  uploadPhoto: task(function * (file) {
-    let product = this.modelFor('product');
-    let photo = this.store.createRecord('photo', {
+  @task({ maxConcurrency: 3, enqueue: true })
+  *uploadPhoto(file) {
+    const { product } = this.args;
+    const photo = this.store.createRecord('photo', {
       product,
-      filename: get(file, 'name'),
-      filesize: get(file, 'size')
+      fileName: file.name,
+      fileSize: file.size,
     });
 
     try {
-      file.readAsDataURL().then(function (url) {
-        if (get(photo, 'url') == null) {
-          set(photo, 'url', url);
-        }
-      });
+      const url = yield file.readAsDataURL();
+      if (!photo.url) {
+        photo.url = url;
+      }
 
-      let response = yield file.upload('/api/images/upload');
-      set(photo, 'url', response.headers.Location);
+      const response = yield file.upload('/api/images/upload');
+      photo.url = response.headers.Location;
       yield photo.save();
     } catch (e) {
       photo.rollback();
     }
-  }).maxConcurrency(3).enqueue(),
-
-  actions: {
-    uploadImage(file) {
-      get(this, 'uploadPhoto').perform(file);
-    }
   }
-});
+}
 ```
 
 ## Access to the global list of uploading files
 
 `ember-file-upload` exposes a service called `fileQueue` that exposes aggregate information on files being uploaded in your app.
 
-A common scenario is to alert users that they still have pending uploads when they are about to leave the page. To do this, look at `fileQueue.get('files.length')` to see if there's any files uploading.
+A common scenario is to alert users that they still have pending uploads when they are about to leave the page. To do this, look at `fileQueue.files.length` to see if there's any files uploading.
 
 In addition to the file list, there are properties that indicate how many bytes have been uploaded (`loaded`), the total size of all files in bytes (`size`), and the progress of all files (`progress`). Using these, you may implement a global progress bar indicating files that are uploading in the background.

--- a/tests/dummy/app/templates/docs/recipes.md
+++ b/tests/dummy/app/templates/docs/recipes.md
@@ -20,24 +20,30 @@ For example, creating an image uploader that uploads images to your API server w
       {{#if dropzone.supported}}
         Drag and drop images onto this area to upload them or
       {{/if}}
-      <FileUpload @name="photos"
-                  @for="upload-photo"
-                  @accept="image/*"
-                  @multiple={{true}}
-                  @onFileAdd={{action this.uploadImage}}>
-        <a tabindex=0>Add an Image.</a>
+      <FileUpload
+        @name="photos"
+        @for="upload-photo"
+        @accept="image/*"
+        @multiple={{true}}
+        @onFileAdd={{this.uploadImage}}
+      >
+        <a tabindex="0">Add an Image.</a>
       </FileUpload>
     </p>
   {{/if}}
 </FileDropzone>
 ```
+
 It is also possible for you to create a simple file upload button which yields the queue:
 
 ```handlebars
-<FileUpload @name="photos"
-            @accept="image/*"
-            @onFileAdd={{action this.uploadImage}} as |queue|>
-  <a class="button">
+<FileUpload
+  @name="photos"
+  @accept="image/*"
+  @onFileAdd={{this.uploadImage}}
+  as |queue|
+>
+  <a tabindex="0">
     {{#if queue.files.length}}
       Uploading...
     {{else}}
@@ -46,5 +52,3 @@ It is also possible for you to create a simple file upload button which yields t
   </a>
 </FileUpload>
 ```
-
-Ember FileUpload also supports classic curly component invocation.

--- a/tests/dummy/app/templates/docs/testing.md
+++ b/tests/dummy/app/templates/docs/testing.md
@@ -28,8 +28,8 @@ import { upload } from 'ember-file-upload/mirage';
 
 export default function () {
   this.post('/photos/new', upload(function (schema, request) {
-    let { name: filename, size: filesize, url } = request.requestBody.file;
-    let photo = schema.create('photo', { filename, filesize, url, uploadedAt: new Date() });
+    let { name: fileName, size: fileSize, url } = request.requestBody.file;
+    let photo = schema.create('photo', { fileName, fileSize, url, uploadedAt: new Date() });
     return photo;
   }));
 }


### PR DESCRIPTION
Probably best to rebase and merge this after #514

- All classic Route/Controller examples replaced with glimmer component examples
- Use more modern handlebars formatting
- Simplified the `FileUpload` component introduction – complexities of queues etc are explained elsewhere
- Dropped mention of classic(curly) component support

### On Ember Concurrency
Have added it to many examples. It's not a requirement to use with this addon but I believe it's best practice to handle an operation like uploading files with concurrency tasks.