### PR TITLE
feat: conditionally exclude mirage handler from builds

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -26,5 +26,10 @@ module.exports = function (defaults) {
         package: 'qunit',
       },
     ],
+    packagerOptions: {
+      webpackConfig: {
+        devtool: 'source-map',
+      },
+    },
   });
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,35 @@
 'use strict';
+const funnel = require('broccoli-funnel');
 
 module.exports = {
   name: require('./package').name,
+  included(app) {
+    let config = app.project.config();
+
+    this.appEnv = config.environment;
+    this.mirageConfig = config['ember-cli-mirage'] || {};
+
+    this._super.included.apply(this, arguments);
+  },
+  treeForAddon() {
+    let tree = this._super.treeForAddon.apply(this, arguments);
+    return this._shouldIncludeMirageHandler()
+      ? tree
+      : funnel(tree, { exclude: ['ember-file-upload/mirage/*'] });
+  },
+  _shouldIncludeMirageHandler() {
+    if (process.env.EMBER_CLI_FASTBOOT) return false;
+
+    let environment = this.appEnv;
+    let enabledInProd =
+      environment === 'production' && this.mirageConfig.enabled;
+    let explicitExcludeFiles = this.mirageConfig.excludeFilesFromBuild;
+    let shouldIncludeHandler =
+      enabledInProd ||
+      (environment &&
+        environment !== 'production' &&
+        explicitExcludeFiles !== true);
+
+    return shouldIncludeHandler;
+  },
 };

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@ember/test-waiters": "^3.0.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
+    "broccoli-funnel": "^3.0.8",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-modifier": "^2.1.2"


### PR DESCRIPTION
Continuation of #432

@bendemboski 

> Fix CSP for embroider builds by switching the source mapping method to not use eval()
> 
> Note that rather than disabling source maps, I switched to a non-eval form. It's a slow method than others, but it only affects development/testing of ember-file-upload itself, and its build is fast enough that the increased build time is pretty insignificant and, IMO, worthwhile to have sourcemaps.

