### PR TITLE
UploadFile: Restore `name` setter

### DIFF
--- a/addon/upload-file.ts
+++ b/addon/upload-file.ts
@@ -98,14 +98,19 @@ export default class UploadFile {
     return this.#id;
   }
 
+  #name?: string;
+
   /** The file name */
   get name(): string {
-    return this.file?.name;
+    return this.#name ?? this.file?.name;
+  }
+  set name(value: string) {
+    this.#name = value;
   }
 
-  /** The size of the file in bytes. */
   #size = 0;
 
+  /** The size of the file in bytes. */
   get size() {
     return this.#size ?? this.file.size;
   }

--- a/tests/unit/upload-file-test.js
+++ b/tests/unit/upload-file-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { upload as uploadHandler } from 'ember-file-upload/mirage';
-import UploadFile from 'ember-file-upload/upload-file';
+import UploadFile, { FileSource } from 'ember-file-upload/upload-file';
 
 module('Unit | UploadFile', function (hooks) {
   setupTest(hooks);
@@ -63,5 +63,12 @@ module('Unit | UploadFile', function (hooks) {
         baz: 'baz',
       },
     });
+  });
+
+  test('it allows name to be set', function (assert) {
+    const file = new UploadFile(new File([], 'dingus.txt'), FileSource.Browse);
+    assert.strictEqual(file.name, 'dingus.txt');
+    file.name = 'dangus.txt';
+    assert.strictEqual(file.name, 'dangus.txt');
   });
 });


### PR DESCRIPTION
Consumers use this to rename files before uploading them.

I accidentally removed this functionality during the Glimmer migration.

Fixes #680