### PR TITLE
`UploadFile.size `always returns 0

### DIFF
--- a/addon/upload-file.ts
+++ b/addon/upload-file.ts
@@ -112,7 +112,7 @@ export default class UploadFile {
 
   /** The size of the file in bytes. */
   get size() {
-    return this.#size ?? this.file.size;
+    return this.#size || this.file.size;
   }
 
   set size(value) {

--- a/tests/unit/upload-file-test.js
+++ b/tests/unit/upload-file-test.js
@@ -71,4 +71,13 @@ module('Unit | UploadFile', function (hooks) {
     file.name = 'dangus.txt';
     assert.strictEqual(file.name, 'dangus.txt');
   });
+
+  test('it reads the size and allows it to be set', function (assert) {
+    const file = UploadFile.fromBlob(new Blob(['test text'], { type: 'text' }));
+    assert.strictEqual(file.size, 9);
+    assert.strictEqual(file.file.size, 9);
+    file.size = 13;
+    assert.strictEqual(file.size, 13);
+    assert.strictEqual(file.file.size, 9);
+  });
 });


### PR DESCRIPTION
Since #size defaults to 0 this getter was always returning zero and
never the size of the actual file. I'm not sure under what conditions
this value needs to be settable, but I've followed the pattern for
testing the name and fixed the getter.

Maybe this would be better done by setting the default value to null, but I'm not familiar enough with typescript to see how to get that done correctly.