### PR TITLE
FileUpload: Defer onFileAdd callback

### DIFF
--- a/addon/components/file-upload.ts
+++ b/addon/components/file-upload.ts
@@ -5,6 +5,7 @@ import UploadFile from 'ember-file-upload/upload-file';
 import Queue from '../queue';
 import FileQueueService, { DEFAULT_QUEUE } from '../services/file-queue';
 import { guidFor } from '@ember/object/internals';
+import { next } from '@ember/runloop';
 
 interface FileUploadArgs {
   queue?: Queue;
@@ -117,6 +118,6 @@ export default class FileUploadComponent extends Component<FileUploadArgs> {
   });
 
   fileAdded(file: UploadFile) {
-    this.args.onFileAdd?.(file);
+    if (this.args.onFileAdd) next(this, this.args.onFileAdd, file);
   }
 }

--- a/tests/integration/components/file-upload-test.js
+++ b/tests/integration/components/file-upload-test.js
@@ -35,6 +35,22 @@ module('Integration | Component | FileUpload', function (hooks) {
     assert.verifySteps(['dingus.txt', 'dingus.png']);
   });
 
+  test('uploading multiple files defers onFileAdd callback until all files are added', async function (assert) {
+    this.onFileAdd = (file) => assert.step(file.queue.files.length.toString());
+
+    await render(
+      hbs`<FileUpload @name="test" @onFileAdd={{this.onFileAdd}} />`
+    );
+
+    await selectFiles(
+      'input[type="file"]',
+      new File([], 'dingus.txt'),
+      new File([], 'dingus.png')
+    );
+
+    assert.verifySteps(['2', '2']);
+  });
+
   test('only calls onFileAdd for filtered files', async function (assert) {
     this.filter = (file) => {
       assert.step(`filter: ${file.name}`);


### PR DESCRIPTION
Fixes a regression where uploading multiple files would run syncronously where previously the callbacks were deferred.

Fixes #697