### PR TITLE
Prefix all callbacks with `on`

### DIFF
--- a/ember-file-upload/addon/components/file-dropzone.ts
+++ b/ember-file-upload/addon/components/file-dropzone.ts
@@ -168,7 +168,7 @@ export default class FileDropzoneComponent extends Component<FileDropzoneArgs> {
     return () => this.queue.removeListener(this);
   });
 
-  fileAdded(file: UploadFile) {
+  onFileAdded(file: UploadFile) {
     this.args.onFileAdd?.(file);
   }
 

--- a/ember-file-upload/addon/components/file-upload.hbs
+++ b/ember-file-upload/addon/components/file-upload.hbs
@@ -12,7 +12,7 @@
     multiple={{@multiple}}
     disabled={{@disabled}}
     hidden
-    {{this.queue.selectFile filter=@filter filesSelected=@filesSelected}}
+    {{this.queue.selectFile filter=@filter onFilesSelected=@onFilesSelected}}
   />
 
   {{yield this.queue}}

--- a/ember-file-upload/addon/components/file-upload.ts
+++ b/ember-file-upload/addon/components/file-upload.ts
@@ -14,7 +14,7 @@ interface FileUploadArgs {
   filter?: (file: UploadFile) => boolean;
 
   // events
-  filesSelected?: (files: UploadFile[]) => void;
+  onFilesSelected?: (files: UploadFile[]) => void;
 
   // old/deprecated API
 
@@ -47,7 +47,7 @@ interface FileUploadArgs {
   for?: string;
 
   /**
-   * @deprecated use `filesSelected()` instead
+   * @deprecated use `onFilesSelected()` instead
    */
   onFileAdd: (file: UploadFile) => void;
 }

--- a/ember-file-upload/addon/components/file-upload.ts
+++ b/ember-file-upload/addon/components/file-upload.ts
@@ -110,7 +110,7 @@ export default class FileUploadComponent extends Component<FileUploadArgs> {
     return () => this.queue.removeListener(this);
   });
 
-  fileAdded(file: UploadFile) {
+  onFileAdded(file: UploadFile) {
     if (this.args.onFileAdd) next(this, this.args.onFileAdd, file);
   }
 }

--- a/ember-file-upload/addon/helpers/file-queue.ts
+++ b/ember-file-upload/addon/helpers/file-queue.ts
@@ -8,8 +8,8 @@ import { DEFAULT_QUEUE } from '../services/file-queue';
 
 interface FileQueueArgs {
   name?: string;
-  fileAdded?: (file: UploadFile) => void;
-  fileRemoved?: (file: UploadFile) => void;
+  onFileAdded?: (file: UploadFile) => void;
+  onFileRemoved?: (file: UploadFile) => void;
 }
 
 /**
@@ -53,11 +53,11 @@ export default class FileQueueHelper extends Helper implements QueueListener {
     return queue;
   }
 
-  fileAdded(file: UploadFile) {
-    this.args.fileAdded?.(file);
+  onFileAdded(file: UploadFile) {
+    this.args.onFileAdded?.(file);
   }
 
-  fileRemoved(file: UploadFile) {
-    this.args.fileRemoved?.(file);
+  onFileRemoved(file: UploadFile) {
+    this.args.onFileRemoved?.(file);
   }
 }

--- a/ember-file-upload/addon/queue.ts
+++ b/ember-file-upload/addon/queue.ts
@@ -12,8 +12,8 @@ export interface SelectFileModifierArgs extends ModifierArgs {
 }
 
 export interface QueueListener {
-  fileAdded?(file: UploadFile): void;
-  fileRemoved?(file: UploadFile): void;
+  onFileAdded?(file: UploadFile): void;
+  onFileRemoved?(file: UploadFile): void;
 }
 
 export type QueueName = string | symbol;
@@ -147,7 +147,7 @@ export default class Queue {
     this.#distinctFiles.add(file);
 
     for (const listener of this.#listeners) {
-      listener.fileAdded?.(file);
+      listener.onFileAdded?.(file);
     }
   }
 
@@ -165,7 +165,7 @@ export default class Queue {
     this.#distinctFiles.delete(file);
 
     for (const listener of this.#listeners) {
-      listener.fileRemoved?.(file);
+      listener.onFileRemoved?.(file);
     }
   }
 

--- a/ember-file-upload/addon/queue.ts
+++ b/ember-file-upload/addon/queue.ts
@@ -7,7 +7,7 @@ import FileQueueService from './services/file-queue';
 export interface SelectFileModifierArgs extends ModifierArgs {
   named: {
     filter?: (file: File) => boolean;
-    filesSelected?: (files: UploadFile[]) => void;
+    onFilesSelected?: (files: UploadFile[]) => void;
   };
 }
 
@@ -226,7 +226,7 @@ export default class Queue {
         }
       }
 
-      named.filesSelected?.(selectedFiles);
+      named.onFilesSelected?.(selectedFiles);
 
       // this will reset the input, so the _same_ file can be picked again
       // Without, the `change` event wouldn't be fired, as it is still the same

--- a/ember-file-upload/tests/dummy/app/components/demo-upload.hbs
+++ b/ember-file-upload/tests/dummy/app/components/demo-upload.hbs
@@ -1,4 +1,4 @@
-{{#let (file-queue name="photos" fileAdded=this.uploadProof) as |queue|}}
+{{#let (file-queue name="photos" onFileAdded=this.uploadProof) as |queue|}}
   <div class="docs-my-8 text-center">
     <FileDropzone @queue={{queue}} class="demo-dropzone" as |dropzone|>
       <div class="dropzone-upload-area upload {{if dropzone.active "active"}}">

--- a/ember-file-upload/tests/helpers/file-queue-helper-test.js
+++ b/ember-file-upload/tests/helpers/file-queue-helper-test.js
@@ -39,7 +39,7 @@ module('Integration | Helper | file-queue', function (hooks) {
     await render(hbs`
       {{#let (file-queue) as |queue|}}
         <label>
-          <input type="file" {{queue.selectFile filesSelected=this.selectFiles}} hidden>
+          <input type="file" {{queue.selectFile onFilesSelected=this.selectFiles}} hidden>
           Select File
         </label>
       {{/let}}

--- a/ember-file-upload/tests/helpers/file-queue-helper-test.js
+++ b/ember-file-upload/tests/helpers/file-queue-helper-test.js
@@ -81,7 +81,7 @@ module('Integration | Helper | file-queue', function (hooks) {
     this.removeFile = (file) => assert.step(`file removed: ${file.name}`);
 
     await render(hbs`
-      {{#let (file-queue fileAdded=this.addFile fileRemoved=this.removeFile) as |queue|}}
+      {{#let (file-queue onFileAdded=this.addFile onFileRemoved=this.removeFile) as |queue|}}
         {{#each queue.files as |file|}}
           <span data-test-file>
           {{file.name}}
@@ -127,7 +127,7 @@ module('Integration | Helper | file-queue', function (hooks) {
     };
 
     await render(hbs`
-      {{#let (file-queue fileAdded=this.uploadImage) as |queue|}}
+      {{#let (file-queue onFileAdded=this.uploadImage) as |queue|}}
         {{#each queue.files as |file|}}
           <span data-test-file>
           {{file.name}}

--- a/ember-file-upload/tests/integration/queue-listeners-test.js
+++ b/ember-file-upload/tests/integration/queue-listeners-test.js
@@ -31,7 +31,7 @@ module('Integration | queue listeners', function (hooks) {
     ]);
   };
 
-  test('attaches and detaches filesSelected from queue', async function (assert) {
+  test('attaches and detaches onFilesSelected from queue', async function (assert) {
     assert.expect(3);
     setupState.bind(this)();
 
@@ -46,12 +46,12 @@ module('Integration | queue listeners', function (hooks) {
       {{#if this.state.firstComponent}}
         <FileUpload
           @queue={{this.queue}}
-          @filesSelected={{this.firstListener}}
+          @onFilesSelected={{this.firstListener}}
         />
       {{else}}
         <FileUpload
           @queue={{this.queue}}
-          @filesSelected={{this.secondListener}}
+          @onFilesSelected={{this.secondListener}}
         />
       {{/if}}
     `);


### PR DESCRIPTION
Attempting to bring all callback naming to a consistent format.

Fixes #701