### PR TITLE
Remove whitespace when rendering FileUpload

### DIFF
--- a/ember-file-upload/addon/components/file-upload.hbs
+++ b/ember-file-upload/addon/components/file-upload.hbs
@@ -4,6 +4,7 @@
   ...attributes
   {{this.bindListeners}}
 >
+  {{~!~}}
   <input
     id={{this.for}}
     type="file"
@@ -15,6 +16,6 @@
     {{this.queue.selectFile filter=@filter onFilesSelected=@onFilesSelected}}
   />
 
-  {{yield this.queue}}
+  {{~yield this.queue~}}
 </label>
-
+{{~!~}}

--- a/ember-file-upload/tests/integration/components/file-upload-test.js
+++ b/ember-file-upload/tests/integration/components/file-upload-test.js
@@ -91,4 +91,10 @@ module('Integration | Component | FileUpload', function (hooks) {
     assert.dom('input[type="file"]').hasAttribute('disabled');
     assert.dom('input[type="file"]').hasAttribute('capture');
   });
+
+  test('renders with inline display', async function (assert) {
+    await render(hbs`(<FileUpload>label</FileUpload>)`);
+
+    assert.dom(this.element).hasText('(label)');
+  });
 });


### PR DESCRIPTION
Adds a test and proposes a possible fix for https://github.com/adopted-ember-addons/ember-file-upload/issues/709.

`{{~!~}}` syntax from https://discuss.emberjs.com/t/removing-whitespace-with-angle-bracket-syntax/17094/3.