### PR TITLE
Automate dependency upgrades within SemVer range

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,43 +1,11 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":preserveSemverRanges",
+    ":maintainLockFilesWeekly"
   ],
-  "ignoreDeps": [
-    "@ember/optional-features",
-    "@types/ember__application",
-    "@types/ember__array",
-    "@types/ember__component",
-    "@types/ember__controller",
-    "@types/ember__debug",
-    "@types/ember__destroyable",
-    "@types/ember__engine",
-    "@types/ember__error",
-    "@types/ember__object",
-    "@types/ember__polyfills",
-    "@types/ember__routing",
-    "@types/ember__runloop",
-    "@types/ember__service",
-    "@types/ember__string",
-    "@types/ember__template",
-    "@types/ember__test",
-    "@types/ember__utils",
-    "broccoli-asset-rev",
-    "ember-cli-babel",
-    "ember-cli-dependency-checker",
-    "ember-cli-htmlbars",
-    "ember-cli-inject-live-reload",
-    "ember-cli",
-    "ember-data",
-    "ember-load-initializers",
-    "ember-maybe-import-regenerator",
-    "ember-qunit",
-    "ember-resolver",
-    "ember-source",
-    "eslint-plugin-ember",
-    "loader.js",
-    "qunit-dom"
-  ],
+  "lockFileMaintenance": {
+    "automerge": true
+  },
   "postUpdateOptions": ["yarnDedupeFewer"],
-  "rangeStrategy": "update-lockfile"
 }
-

--- a/renovate.json
+++ b/renovate.json
@@ -8,4 +8,10 @@
     "automerge": true
   },
   "postUpdateOptions": ["yarnDedupeFewer"],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["@types/ember__"],
+      "groupName": "ember types"
+    }
+  ]
 }


### PR DESCRIPTION
This configures RenovateBot to

1. manage all dependencies,
2. upgrade all dependencies within SemVer range at once weekly by recreating `yarn.lock`,
3. merge such upgrades within SemVer range automatically if tests are passing and
4. group all upgrades of Ember types into one single merge request.

RenovateBot will continue to create separate merge requests for every dependency upgrade, which requires a change to the SemVer range. Such dependency upgrades need to be reviewed and merge manually.

This also helps to avoid running into a bug of RenovateBot, which causes `yarn.lock` files with missing `resolved` and `integrity` members for a dependency: https://github.com/renovatebot/renovate/issues/13804

Ignoring Ember dependencies is not needed anymore. This was needed earlier because Ember CLI Update determined the version of the blueprints to upgrade based on the `ember-cli` dependency version in the project. This has been replaced by an [`ember-cli-update.json`](https://github.com/adopted-ember-addons/ember-file-upload/blob/master/ember-file-upload/tests/dummy/config/ember-cli-update.json), which contains information about latest blueprint upgrades. Also compatibility of dependencies with different Ember version has been improved _a lot_ in the last years. No need to upgrade all of them with Ember CLI Update. The latest versions work very well in my experience even if SemVer ranges in blueprints are not yet upgraded to use them.

Relevant parts from RenovateBot documentation for used presets and configuration options:

> `lockFileMaintenance`
>
> This feature can be used to refresh lock files and keep them up-to-date. "Maintaining" a lock file means recreating it so that every dependency version within it is updated to the latest.
> 
> https://docs.renovatebot.com/configuration-options/#lockfilemaintenance

> :maintainLockFilesWeekly
>
> Run lock file maintenance (updates) early Monday mornings
>
> https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly

> :preserveSemverRanges
>
> Preserve (but continue to upgrade) any existing SemVer ranges
>
> https://docs.renovatebot.com/presets-default/#preservesemverranges