### PR TITLE
Move DragListenerModifier to its own file

### DIFF
--- a/ember-file-upload/addon/components/file-dropzone.ts
+++ b/ember-file-upload/addon/components/file-dropzone.ts
@@ -7,15 +7,11 @@ import { tracked } from '@glimmer/tracking';
 import Queue from '../queue';
 import UploadFile from 'ember-file-upload/upload-file';
 import FileQueueService, { DEFAULT_QUEUE } from '../services/file-queue';
-import Modifier, { modifier } from 'ember-modifier';
+import { modifier } from 'ember-modifier';
 import { deprecate } from '@ember/debug';
 import { isPresent } from '@ember/utils';
-import {
-  FileUploadDragEvent,
-  FileSource,
-  DragListenerModifierArgs,
-} from 'ember-file-upload/interfaces';
-import DragListener from 'ember-file-upload/system/drag-listener';
+import { FileUploadDragEvent, FileSource } from 'ember-file-upload/interfaces';
+import DragListenerModifier from '../system/drag-listener-modifier';
 
 interface FileDropzoneArgs {
   queue?: Queue;
@@ -412,23 +408,5 @@ export default class FileDropzoneComponent extends Component<FileDropzoneArgs> {
     return addedFiles;
   }
 
-  dragListener = class DragListenerModifier extends Modifier<DragListenerModifierArgs> {
-    listener = new DragListener();
-
-    didReceiveArguments() {
-      const { dragenter, dragleave, dragover, drop } = this.args.named;
-
-      this.listener.removeEventListeners(this.element);
-      this.listener.addEventListeners(this.element, {
-        dragenter,
-        dragleave,
-        dragover,
-        drop,
-      });
-    }
-
-    willRemove() {
-      this.listener.removeEventListeners(this.element);
-    }
-  };
+  dragListener = DragListenerModifier;
 }

--- a/ember-file-upload/addon/interfaces.ts
+++ b/ember-file-upload/addon/interfaces.ts
@@ -106,7 +106,6 @@ export interface HTTPRequestResponse {
 }
 
 export interface DragListenerModifierArgs {
-  positional: [];
   named: DragListenerHandlers;
 }
 

--- a/ember-file-upload/addon/system/drag-listener-modifier.ts
+++ b/ember-file-upload/addon/system/drag-listener-modifier.ts
@@ -1,0 +1,23 @@
+import Modifier from 'ember-modifier';
+import { DragListenerModifierArgs } from 'ember-file-upload/interfaces';
+import DragListener from './drag-listener';
+
+export default class DragListenerModifier extends Modifier<DragListenerModifierArgs> {
+  listener = new DragListener();
+
+  didReceiveArguments() {
+    const { dragenter, dragleave, dragover, drop } = this.args.named;
+
+    this.listener.removeEventListeners(this.element);
+    this.listener.addEventListeners(this.element, {
+      dragenter,
+      dragleave,
+      dragover,
+      drop,
+    });
+  }
+
+  willRemove() {
+    this.listener.removeEventListeners(this.element);
+  }
+}

--- a/ember-file-upload/tsconfig.json
+++ b/ember-file-upload/tsconfig.json
@@ -22,16 +22,6 @@
     "experimentalDecorators": true,
     "skipLibCheck": true,
     "paths": {
-      "dummy/tests/*": [
-        "tests/*"
-      ],
-      "dummy/mirage/*": [
-        "tests/dummy/mirage/*"
-      ],
-      "dummy/*": [
-        "tests/dummy/app/*",
-        "app/*"
-      ],
       "ember-file-upload": [
         "addon"
       ],


### PR DESCRIPTION
Ran into some strange errrors during typescript compilation. I've resolved them by moving this modifier into `system` – since it's not public API and shouldn't be available directly in consuming apps.

Also removed some references to the deleted dummy app from tsconfig.