### PR TITLE
Attempting to fix TypeScript errors

### DIFF
--- a/ember-file-upload/addon/components/file-dropzone.ts
+++ b/ember-file-upload/addon/components/file-dropzone.ts
@@ -4,7 +4,7 @@ import { getOwner } from '@ember/application';
 import DataTransferWrapper from '../system/data-transfer-wrapper';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import Queue from '../queue';
+import Queue from 'ember-file-upload/queue';
 import UploadFile from 'ember-file-upload/upload-file';
 import FileQueueService, { DEFAULT_QUEUE } from '../services/file-queue';
 import { modifier } from 'ember-modifier';

--- a/ember-file-upload/addon/components/file-upload.ts
+++ b/ember-file-upload/addon/components/file-upload.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { modifier } from 'ember-modifier';
 import UploadFile from 'ember-file-upload/upload-file';
-import Queue from '../queue';
+import Queue from 'ember-file-upload/queue';
 import FileQueueService, { DEFAULT_QUEUE } from '../services/file-queue';
 import { guidFor } from '@ember/object/internals';
 import { next } from '@ember/runloop';

--- a/ember-file-upload/addon/helpers/file-queue.ts
+++ b/ember-file-upload/addon/helpers/file-queue.ts
@@ -1,9 +1,10 @@
 import Helper from '@ember/component/helper';
 import { registerDestructor } from '@ember/destroyable';
 import { inject as service } from '@ember/service';
-import UploadFile from '../upload-file';
-import type FileQueueService from '../services/file-queue';
-import { DEFAULT_QUEUE } from '../services/file-queue';
+import UploadFile from 'ember-file-upload/upload-file';
+import FileQueueService, {
+  DEFAULT_QUEUE,
+} from 'ember-file-upload/services/file-queue';
 import { QueueListener } from 'ember-file-upload/interfaces';
 
 interface FileQueueArgs {

--- a/ember-file-upload/addon/queue.ts
+++ b/ember-file-upload/addon/queue.ts
@@ -1,8 +1,8 @@
 import { action } from '@ember/object';
 import { modifier } from 'ember-modifier';
 import { TrackedSet } from 'tracked-built-ins';
-import UploadFile from './upload-file';
-import FileQueueService from './services/file-queue';
+import UploadFile from 'ember-file-upload/upload-file';
+import FileQueueService from 'ember-file-upload/services/file-queue';
 import { deprecate } from '@ember/debug';
 import {
   FileSource,

--- a/ember-file-upload/addon/queue.ts
+++ b/ember-file-upload/addon/queue.ts
@@ -37,7 +37,7 @@ export default class Queue {
    * photos, the good name for this queue may be `"photos"`.
    *
    * If you're uploading images to an artwork, the
-   * best name would incoporate both `"artworks"` and
+   * best name would incorporate both `"artworks"` and
    * the identifier of the artwork. A good name for this
    * queue may be `"artworks/{{id}}/photos"`, where `{{id}}`
    * is a dynamic segment that is generated from the artwork id.
@@ -62,7 +62,7 @@ export default class Queue {
    * file from its queue. Upload failures can happen due to a
    * timeout or a server response. If you choose to use the
    * `abort` method, the file will fail to upload, but will
-   * be removed from the requeuing proccess, and will be
+   * be removed from the requeuing process, and will be
    * considered to be in a settled state.
    *
    * @defaultValue []

--- a/ember-file-upload/addon/services/file-queue.ts
+++ b/ember-file-upload/addon/services/file-queue.ts
@@ -1,8 +1,8 @@
 import { assert } from '@ember/debug';
 import Service from '@ember/service';
 import { registerDestructor } from '@ember/destroyable';
-import Queue from '../queue';
-import UploadFile from '../upload-file';
+import Queue from 'ember-file-upload/queue';
+import UploadFile from 'ember-file-upload/upload-file';
 import { QueueName } from 'ember-file-upload/interfaces';
 
 export const DEFAULT_QUEUE = Symbol('DEFAULT_QUEUE');

--- a/ember-file-upload/addon/system/upload.ts
+++ b/ember-file-upload/addon/system/upload.ts
@@ -2,12 +2,8 @@ import { assert } from '@ember/debug';
 import HTTPRequest from './http-request';
 import RSVP from 'rsvp';
 import { buildWaiter } from '@ember/test-waiters';
-import UploadFile from 'ember-file-upload/upload-file';
-import {
-  FileState,
-  HTTPRequestResponse,
-  UploadOptions,
-} from 'ember-file-upload/interfaces';
+import UploadFile from '../upload-file';
+import { FileState, HTTPRequestResponse, UploadOptions } from '../interfaces';
 
 const uploadWaiter = buildWaiter('ember-file-upload:upload');
 

--- a/ember-file-upload/addon/upload-file.ts
+++ b/ember-file-upload/addon/upload-file.ts
@@ -155,7 +155,7 @@ export default class UploadFile {
    */
   uploadBinary(url: string, options: UploadOptions) {
     options.contentType = 'application/octet-stream';
-    return upload(this, url, options, (request) => {
+    return upload(this as UploadFile, url, options, (request) => {
       return request.send(this.file);
     });
   }
@@ -168,7 +168,7 @@ export default class UploadFile {
    */
   upload(url: string, options?: UploadOptions) {
     return upload(
-      this,
+      this as UploadFile,
       url,
       options,
       (

--- a/ember-file-upload/addon/upload-file.ts
+++ b/ember-file-upload/addon/upload-file.ts
@@ -4,7 +4,7 @@ import { upload } from './system/upload';
 import HTTPRequest from './system/http-request';
 import UploadFileReader from './system/upload-file-reader';
 
-import Queue from './queue';
+import Queue from 'ember-file-upload/queue';
 import { guidFor } from '@ember/object/internals';
 import RSVP from 'rsvp';
 import {
@@ -12,7 +12,7 @@ import {
   FileState,
   HTTPRequestResponse,
   UploadOptions,
-} from 'ember-file-upload/interfaces';
+} from './interfaces';
 
 /**
  * Files provide a uniform interface for interacting

--- a/ember-file-upload/addon/upload-file.ts
+++ b/ember-file-upload/addon/upload-file.ts
@@ -20,13 +20,13 @@ import {
  */
 export default class UploadFile {
   file: File;
-  #source: FileSource;
+  private _source: FileSource;
 
   queue?: Queue;
 
   constructor(file: File, source: FileSource) {
     this.file = file;
-    this.#source = source;
+    this._source = source;
   }
 
   /**
@@ -36,35 +36,35 @@ export default class UploadFile {
    * content.
    */
   get source(): FileSource {
-    return this.#source;
+    return this._source;
   }
 
-  #id = `file-${guidFor(this)}`;
+  private _id = `file-${guidFor(this)}`;
 
   /** A unique id generated for this file. */
   get id(): string {
-    return this.#id;
+    return this._id;
   }
 
-  #name?: string;
+  private _name?: string;
 
   /** The file name */
   get name(): string {
-    return this.#name ?? this.file?.name;
+    return this._name ?? this.file?.name;
   }
   set name(value: string) {
-    this.#name = value;
+    this._name = value;
   }
 
-  #size = 0;
+  private _size = 0;
 
   /** The size of the file in bytes. */
   get size() {
-    return this.#size || this.file.size;
+    return this._size || this.file.size;
   }
 
   set size(value) {
-    this.#size = value;
+    this._size = value;
   }
 
   /**


### PR DESCRIPTION
I have to say there is a huge part of TypeScript witchcraft ✨ 
After upgrading to 5.1.0, we keep experiencing these reports:

```
Found 8 errors.

  - name: Error
  - nodeAnnotation: [undefined]
  - nodeName: [undefined]
  - originalErrorMessage: [undefined]
  - stack: Error: Command failed with exit code 2: tsc --allowJs false --noEmit false --rootDir /home/runner/work/***/*** --isolatedModules false --declaration --declarationDir /home/runner/work/***/***/e-c-ts-precompile-1751 --emitDeclarationOnly --pretty true
addon/components/sm-previewable-dropzone.ts:92:5 - error TS2322: Type 'string | ArrayBuffer | null' is not assignable to type 'string | null'.
  Type 'ArrayBuffer' is not assignable to type 'string'.

92     this.previewBase64Url = base64;
       ~~~~~~~~~~~~~~~~~~~~~

node_modules/ember-file-upload/addon/queue.ts:156:30 - error TS2345: Argument of type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/addon/upload-file").default' is not assignable to parameter of type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/upload-file").default'.
  Property '#private' is missing in type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/addon/upload-file").default' but required in type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/upload-file").default'.

156       listener.onFileAdded?.(file);
                                 ~~~~

  node_modules/ember-file-upload/upload-file.d.ts:9:5
    9     #private;
          ~~~~~~~~
    '#private' is declared here.

node_modules/ember-file-upload/addon/queue.ts:174:32 - error TS2345: Argument of type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/addon/upload-file").default' is not assignable to parameter of type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/upload-file").default'.

174       listener.onFileRemoved?.(file);
                                   ~~~~

node_modules/ember-file-upload/addon/queue.ts:236:31 - error TS2345: Argument of type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/addon/upload-file").default[]' is not assignable to parameter of type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/upload-file").default[]'.
  Type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/addon/upload-file").default' is not assignable to type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/upload-file").default'.

236       named.onFilesSelected?.(selectedFiles);
                                  ~~~~~~~~~~~~~

node_modules/ember-file-upload/addon/services/file-queue.ts:118:5 - error TS2717: Subsequent property declarations must have the same type.  Property ''file-queue'' must be of type 'FileQueueService', but here has type 'FileQueueService'.

118     'file-queue': FileQueueService;
        ~~~~~~~~~~~~

  node_modules/ember-file-upload/services/file-queue.d.ts:71:9
    71         'file-queue': FileQueueService;
               ~~~~~~~~~~~~
    ''file-queue'' was also declared here.

node_modules/ember-file-upload/addon/upload-file.ts:158:19 - error TS2345: Argument of type 'this' is not assignable to parameter of type 'UploadFile'.
  Property '#private' is missing in type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/addon/upload-file").default' but required in type 'import("/home/runner/work/***/***/node_modules/ember-file-upload/upload-file").default'.

158     return upload(this, url, options, (request) => {
                      ~~~~

  node_modules/ember-file-upload/upload-file.d.ts:9:5
    9     #private;
          ~~~~~~~~
    '#private' is declared here.

node_modules/ember-file-upload/addon/upload-file.ts:171:7 - error TS2345: Argument of type 'this' is not assignable to parameter of type 'UploadFile'.

171       this,
          ~~~~

node_modules/ember-file-upload/queue.d.ts:97:42 - error TS2694: Namespace '"/home/runner/work/***/***/node_modules/ember-modifier/index"' has no exported member 'FunctionBasedModifier'.

97     selectFile: import("ember-modifier").FunctionBasedModifier<{
                                            ~~~~~~~~~~~~~~~~~~~~~
```

## Issues we can ignore because that are related to our project:

- `97     selectFile: import("ember-modifier").FunctionBasedModifier<{` 👉 fixed with upgrading ember-modifier into our project
- `92     this.previewBase64Url = base64;` 👉 fixed in our project (the "issue" is because the "cancellablePromise" can return several [types](https://github.com/adopted-ember-addons/ember-file-upload/blob/master/ember-file-upload/addon/system/upload-file-reader.ts#L70)

## Issues I fixed

- ` '#private' is declared here.`  👉 It appears that TypeScript prefers using the `private field` notation instead of `#field` https://github.com/microsoft/TypeScript/issues/38050 - I agree we can feel like it's not the "modern" way to write things
- I noticed some files could have different typing files because of different paths 👉 I suggest we use Ember aliases instead of relative paths
- I fixed the service injecting (https://github.com/typed-ember/ember-cli-typescript/blob/master/docs/ember/services.md#using-services) - which was already correct on every injection except into the FileQueueHelper

Let me know if I can help!
To test things out, I ran `ember ts:precompile` and replace `ember-file-upload` folder in my project `node_modules`