### PR TITLE
Track `queues` map in `FileQueue` service

### DIFF
--- a/test-app/tests/integration/services/file-queue-test.js
+++ b/test-app/tests/integration/services/file-queue-test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import UploadFile from 'ember-file-upload/upload-file';
+import { FileSource } from 'ember-file-upload/interfaces';
+
+module('Integration | Service | file queue', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('files is reactive', async function (assert) {
+    this.subject = this.owner.lookup('service:file-queue');
+
+    const existingQueue = this.subject.create('existing-queue');
+    const existingQueueFile = new UploadFile(new File([], 'existing-queue-file.txt'), FileSource.Browse);
+    existingQueue.add(existingQueueFile);
+
+    await render(hbs`
+      <div id="files">
+        {{#each this.subject.files as |file|}}
+          {{file.name}}
+        {{/each}}
+      </div>
+    `);
+
+    assert.dom('#files').containsText('existing-queue-file.txt', 'renders existing queue file');
+
+    const newQueue = this.subject.create('new-queue');
+    const newQueueFile = new UploadFile(new File([], 'new-queue-file.txt'), FileSource.Browse);
+    newQueue.add(newQueueFile);
+
+    await settled();
+
+    assert.dom('#files').containsText('existing-queue-file.txt', 'renders existing queue file');
+    assert.dom('#files').containsText('new-queue-file.txt', 'renders new queue file');
+  });
+
+});


### PR DESCRIPTION
As pointed out in #773

> To display all uploading files in queues it would be nice to make the Map a TrackedMap.

Since this property wasn't tracked some of the public API of the `FileQueue` service was not reactive.

Have implemented with the suggestion by @jelhan to

> introduce an untracked map to check existence of a queue without reading the tracked map of queues.

Includes a regression test which fails without using `TrackedMap`.