### PR TITLE
Listen for drag-and-drop events on the Dropzone element rather than document

### DIFF
--- a/ember-file-upload/addon/system/drag-listener-modifier.ts
+++ b/ember-file-upload/addon/system/drag-listener-modifier.ts
@@ -4,14 +4,13 @@ import DragListener from './drag-listener';
 import { registerDestructor } from '@ember/destroyable';
 
 function cleanup(instance: DragListenerModifier) {
-  if (!instance.dragElement) return;
+  if (!instance.listener) return;
 
-  instance.listener.removeEventListeners(instance.dragElement);
+  instance.listener.removeEventListeners();
 }
 
 export default class DragListenerModifier extends Modifier<DragListenerModifierSignature> {
-  listener = new DragListener();
-  dragElement?: Element;
+  listener?: DragListener;
 
   constructor(owner: unknown, args: ArgsFor<DragListenerModifierSignature>) {
     super(owner, args);
@@ -19,7 +18,7 @@ export default class DragListenerModifier extends Modifier<DragListenerModifierS
   }
 
   modify(
-    element: Element,
+    dropzone: Element,
     _: [],
     {
       dragenter,
@@ -28,10 +27,10 @@ export default class DragListenerModifier extends Modifier<DragListenerModifierS
       drop,
     }: NamedArgs<DragListenerModifierSignature>
   ) {
-    this.dragElement = element;
+    this.listener = new DragListener(dropzone);
 
-    this.listener.removeEventListeners(element);
-    this.listener.addEventListeners(element, {
+    this.listener.removeEventListeners();
+    this.listener.addEventListeners({
       dragenter,
       dragleave,
       dragover,

--- a/test-app/tests/integration/components/file-dropzone-test.js
+++ b/test-app/tests/integration/components/file-dropzone-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
   dragAndDrop,
@@ -158,5 +158,20 @@ module('Integration | Component | FileDropzone', function (hooks) {
     );
 
     assert.verifySteps(['dingus.txt']);
+  });
+
+  // Check for regression of: https://github.com/adopted-ember-addons/ember-file-upload/issues/446
+  test('regression: drop events from other DOM nodes are not prevented', async function (assert) {
+    this.documentDragListener = () => assert.step('documentDragListener called');
+    await render(hbs`
+      <FileDropzone @queue={{this.queue}} />
+
+      <div class="independent-drag-target"></div>
+    `);
+    document.addEventListener('drop', this.documentDragListener);
+
+    await triggerEvent('.independent-drag-target', 'drop');
+
+    assert.verifySteps(['documentDragListener called'], 'event reached documentDragListener');
   });
 });


### PR DESCRIPTION
Think I was able to reproduce the reported issue using a regression test.

Refactored `DragListener` to attach and remove all events from the Dropzone element itself.

In the pre-Octane design there was a global `DragListener`. This would be more efficient for a page with many Dropzones and could be addressed in a further refactor. For now though, this does not change performance, and hopefully fixes the reported issue (Fixes #446).

Also replaced some `this` context binding with the action decorator as I'm not sure the event listener removal was using the same functions as the event listener addition.