### PR TITLE
Implement `UploadFile#replaceWithType`

### DIFF
--- a/docs/api/class/upload-file.md
+++ b/docs/api/class/upload-file.md
@@ -73,6 +73,7 @@ The `source` property can be one of the following:
 | -------------------- | --------------------------------------------------------- | ----------------------------------------------- | ------------------ |
 | `upload`             | Upload file to your server.                               | `url: string, options: Record<string, unknown>` | `Promise<unknown>` |
 | `uploadBinary`       | Upload file with `application/octet-stream` content type. | `url: string, options: Record<string, unknown>` | `Promise<unknown>` |
+| `replaceWithType`    | Asynchronously replace file with specified MIME type.     | `type: string`                                  | `Promise<void>`    |
 | `readAsArrayBuffer`  | Upload file with `application/octet-stream` content type. |                                                 | `Promise`          |
 | `readAsDataUrl`      | Resolves with Blob as DataURL.                            |                                                 | `Promise`          |
 | `readAsBinaryString` | Resolves with Blob as binary string                       |                                                 | `Promise`          |

--- a/ember-file-upload/addon/upload-file.ts
+++ b/ember-file-upload/addon/upload-file.ts
@@ -18,7 +18,7 @@ import {
  * with data that can be uploaded or read.
  */
 export default class UploadFile {
-  file: File;
+  @tracked file: File;
   #source: FileSource;
 
   queue?: Queue;
@@ -73,6 +73,21 @@ export default class UploadFile {
    */
   get type(): string {
     return this.file.type;
+  }
+
+  /*
+   * Allows users to update the MIME type by duplicating the file.
+   *
+   * Necessary because `File` properties are read only.
+   *
+   * Must be an async function rather than a setter since it's an async operation.
+   */
+  async replaceWithType(value: string) {
+    const bits = await this.file.arrayBuffer();
+    this.file = new File([bits], this.name, {
+      lastModified: this.file.lastModified,
+      type: value,
+    });
   }
 
   /**

--- a/test-app/tests/unit/upload-file-test.js
+++ b/test-app/tests/unit/upload-file-test.js
@@ -81,4 +81,11 @@ module('Unit | UploadFile', function (hooks) {
     assert.strictEqual(file.size, 13);
     assert.strictEqual(file.file.size, 9);
   });
+
+  test('replaceWithType', async function (assert) {
+    const file = new UploadFile(new File([], 'dingus.txt', { type: 'text/plain' }), FileSource.Browse);
+    assert.strictEqual(file.type, 'text/plain', 'is original type');
+    await file.replaceWithType('text/csv');
+    assert.strictEqual(file.type, 'text/csv', 'is new type');
+  });
 });


### PR DESCRIPTION
Attempting to help with #778 where the `File.type` reported by browsers is unreliable and results in some types of files failing to upload.