### PR TITLE
Replace usage of ember array prototype .any() with native .some()

### DIFF
--- a/ember-file-upload/addon/mirage/utils.js
+++ b/ember-file-upload/addon/mirage/utils.js
@@ -145,7 +145,7 @@ export async function extractFileMetadata(file) {
 
   // Collapse state of `hasAdditionalMetadata` from multiple pipelines
   // Should be `true` if at least one pipeline succeeded
-  metadata.hasAdditionalMetadata = additionalMetadata.any(
+  metadata.hasAdditionalMetadata = additionalMetadata.some(
     (data) => data.hasAdditionalMetadata
   );
 


### PR DESCRIPTION
Believe this may throw an exception for users who don't have prototype extensions enabled.