### PR TITLE
Disable all prototype extensions in test app

### DIFF
--- a/test-app/config/environment.js
+++ b/test-app/config/environment.js
@@ -11,10 +11,7 @@ module.exports = function (environment) {
         // Here you can enable experimental features on an ember canary build
         // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
       },
-      EXTEND_PROTOTYPES: {
-        // Prevent Ember Data from overriding Date.parse.
-        Date: false,
-      },
+      EXTEND_PROTOTYPES: false,
     },
 
     APP: {


### PR DESCRIPTION
As suggested in #798 – the test suite would not have passed when that prototype usage was introduced.