### PR TITLE
Named export all modules

### DIFF
--- a/docs/api/class/queue.md
+++ b/docs/api/class/queue.md
@@ -9,7 +9,7 @@ The Queue is a collection of files that are being manipulated by the user.
 Queues are designed to persist the state of uploads when a user navigates around your application.
 
 ```js
-import Queue from 'ember-file-upload/queue';
+import { Queue } from 'ember-file-upload';
 ```
 
 ## Queue names

--- a/docs/api/class/upload-file.md
+++ b/docs/api/class/upload-file.md
@@ -7,7 +7,7 @@ category: class
 The `UploadFile` class provides a uniform interface for interacting with data that can be uploaded or read.
 
 ```js
-import UploadFile from 'ember-file-upload/upload-file';
+import { UploadFile } from 'ember-file-upload';
 ```
 
 ## File states

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -54,10 +54,10 @@ A mirage handler is provided which can realistically simulate file uploads, incl
 ```js
 // mirage/config.js
 
-import { upload } from 'ember-file-upload/mirage';
+import { uploadHandler } from 'ember-file-upload';
 
 export default function () {
-  this.post('/photos/new', upload(function (schema, request) {
+  this.post('/photos/new', uploadHandler(function (schema, request) {
     const { name, size, url, width, height, hasAdditionalMetadata } = request.requestBody.file;
     return schema.create('photo', { name, size, url, width, height, hasAdditionalMetadata, uploadedAt: new Date() });
   }));

--- a/ember-file-upload/package.json
+++ b/ember-file-upload/package.json
@@ -130,7 +130,10 @@
     "dist"
   ],
   "exports": {
+    ".": "./dist/index.js",
     "./*": "./dist/*",
+    "./mirage": "./dist/mirage/index.js",
+    "./test-support": "./dist/test-support.js",
     "./addon-main.js": "./addon-main.js"
   },
   "release-it": {

--- a/ember-file-upload/package.json
+++ b/ember-file-upload/package.json
@@ -132,7 +132,6 @@
   "exports": {
     ".": "./dist/index.js",
     "./*": "./dist/*",
-    "./mirage": "./dist/mirage/index.js",
     "./test-support": "./dist/test-support.js",
     "./addon-main.js": "./addon-main.js"
   },

--- a/ember-file-upload/rollup.config.js
+++ b/ember-file-upload/rollup.config.js
@@ -18,6 +18,7 @@ export default defineConfig({
       'helpers/**/*.ts',
       'services/**/*.ts',
       'index.ts',
+      'internal.ts',
       'test-support.ts',
     ]),
 

--- a/ember-file-upload/rollup.config.js
+++ b/ember-file-upload/rollup.config.js
@@ -17,14 +17,8 @@ export default defineConfig({
       'components/**/*.ts',
       'helpers/**/*.ts',
       'services/**/*.ts',
-      'mirage/index.ts',
-      'interfaces.ts',
-      'queue.ts',
-      'upload-file.ts',
+      'index.ts',
       'test-support.ts',
-      'system/upload-file-reader.ts',
-      'system/data-transfer-wrapper.ts',
-      'system/http-request.ts',
     ]),
 
     // These are the modules that should get reexported into the traditional

--- a/ember-file-upload/src/components/file-dropzone.ts
+++ b/ember-file-upload/src/components/file-dropzone.ts
@@ -4,13 +4,13 @@ import { getOwner } from '@ember/application';
 import DataTransferWrapper from '../system/data-transfer-wrapper';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import UploadFile from 'ember-file-upload/upload-file';
+import UploadFile from '../upload-file';
 import FileQueueService, { DEFAULT_QUEUE } from '../services/file-queue';
 import {
   FileUploadDragEvent,
   FileSource,
   FileDropzoneArgs,
-} from 'ember-file-upload/interfaces';
+} from '../interfaces';
 import DragListenerModifier from '../system/drag-listener-modifier';
 
 /**

--- a/ember-file-upload/src/helpers/file-queue.ts
+++ b/ember-file-upload/src/helpers/file-queue.ts
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import type UploadFile from '../upload-file';
 import type FileQueueService from '../services/file-queue';
 import { DEFAULT_QUEUE } from '../services/file-queue';
-import { FileQueueArgs, QueueListener } from 'ember-file-upload/interfaces';
+import { FileQueueArgs, QueueListener } from '../interfaces';
 
 /**
  * `file-queue` helper is one of the core primitives of ember-file-upload.

--- a/ember-file-upload/src/index.ts
+++ b/ember-file-upload/src/index.ts
@@ -1,0 +1,22 @@
+import UploadFile from './upload-file';
+import Queue from './queue';
+import HTTPRequest from './system/http-request';
+import DataTransferWrapper from './system/data-transfer-wrapper';
+import UploadFileReader from './system/upload-file-reader';
+import { FileSource, FileState } from './interfaces';
+import { DEFAULT_QUEUE } from './services/file-queue';
+
+export {
+  // Public API classes
+  Queue,
+  UploadFile,
+  // Undocumented classes
+  HTTPRequest,
+  DataTransferWrapper,
+  UploadFileReader,
+  // Enums
+  FileSource,
+  FileState,
+  // Constants
+  DEFAULT_QUEUE,
+};

--- a/ember-file-upload/src/index.ts
+++ b/ember-file-upload/src/index.ts
@@ -5,11 +5,14 @@ import DataTransferWrapper from './system/data-transfer-wrapper';
 import UploadFileReader from './system/upload-file-reader';
 import { FileSource, FileState } from './interfaces';
 import { DEFAULT_QUEUE } from './services/file-queue';
+import uploadHandler from './mirage/upload-handler';
 
 export {
   // Public API classes
   Queue,
   UploadFile,
+  // Mirage handler
+  uploadHandler,
   // Undocumented classes
   HTTPRequest,
   DataTransferWrapper,

--- a/ember-file-upload/src/index.ts
+++ b/ember-file-upload/src/index.ts
@@ -1,11 +1,8 @@
-import UploadFile from './upload-file';
 import Queue from './queue';
-import HTTPRequest from './system/http-request';
-import DataTransferWrapper from './system/data-transfer-wrapper';
-import UploadFileReader from './system/upload-file-reader';
+import UploadFile from './upload-file';
+import uploadHandler from './mirage/upload-handler';
 import { FileSource, FileState } from './interfaces';
 import { DEFAULT_QUEUE } from './services/file-queue';
-import uploadHandler from './mirage/upload-handler';
 
 export {
   // Public API classes
@@ -13,10 +10,6 @@ export {
   UploadFile,
   // Mirage handler
   uploadHandler,
-  // Undocumented classes
-  HTTPRequest,
-  DataTransferWrapper,
-  UploadFileReader,
   // Enums
   FileSource,
   FileState,

--- a/ember-file-upload/src/interfaces.ts
+++ b/ember-file-upload/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type UploadFile from 'ember-file-upload/upload-file';
+import type UploadFile from './upload-file';
 import type Queue from './queue';
 import type FileQueueService from './services/file-queue';
 import type DataTransferWrapper from './system/data-transfer-wrapper';

--- a/ember-file-upload/src/internal.ts
+++ b/ember-file-upload/src/internal.ts
@@ -1,0 +1,10 @@
+import DataTransferWrapper from './system/data-transfer-wrapper';
+import HTTPRequest from './system/http-request';
+import UploadFileReader from './system/upload-file-reader';
+
+export {
+  // Non-public classes imported by the test app
+  DataTransferWrapper,
+  HTTPRequest,
+  UploadFileReader,
+};

--- a/ember-file-upload/src/mirage/index.ts
+++ b/ember-file-upload/src/mirage/index.ts
@@ -1,1 +1,0 @@
-export { uploadHandler as upload } from './upload-handler';

--- a/ember-file-upload/src/mirage/upload-handler.ts
+++ b/ember-file-upload/src/mirage/upload-handler.ts
@@ -20,7 +20,7 @@ interface FakeRequest {
   };
 }
 
-export function uploadHandler(
+export default function uploadHandler(
   fn: (this: void, db: any, request: FakeRequest) => void,
   options = { network: null, timeout: null }
 ) {

--- a/ember-file-upload/src/services/file-queue.ts
+++ b/ember-file-upload/src/services/file-queue.ts
@@ -3,7 +3,7 @@ import Service from '@ember/service';
 import { registerDestructor } from '@ember/destroyable';
 import Queue from '../queue';
 import type UploadFile from '../upload-file';
-import { QueueName } from 'ember-file-upload/interfaces';
+import { QueueName } from '../interfaces';
 import { TrackedMap } from 'tracked-built-ins';
 
 export const DEFAULT_QUEUE = Symbol('DEFAULT_QUEUE');

--- a/ember-file-upload/src/system/drag-listener-modifier.ts
+++ b/ember-file-upload/src/system/drag-listener-modifier.ts
@@ -1,5 +1,5 @@
 import Modifier, { ArgsFor, NamedArgs } from 'ember-modifier';
-import { DragListenerModifierSignature } from 'ember-file-upload/interfaces';
+import { DragListenerModifierSignature } from '../interfaces';
 import DragListener from './drag-listener';
 import { registerDestructor } from '@ember/destroyable';
 

--- a/ember-file-upload/src/system/drag-listener.ts
+++ b/ember-file-upload/src/system/drag-listener.ts
@@ -6,7 +6,7 @@ import {
   DragEventListener,
   QueuedDragEvent,
   DragListenerHandlers,
-} from 'ember-file-upload/interfaces';
+} from '../interfaces';
 import MutableArray from '@ember/array/mutable';
 import { action } from '@ember/object';
 

--- a/ember-file-upload/src/system/http-request.ts
+++ b/ember-file-upload/src/system/http-request.ts
@@ -1,6 +1,6 @@
 import { bind } from '@ember/runloop';
 import RSVP from 'rsvp';
-import { HTTPRequestOptions } from 'ember-file-upload/interfaces';
+import { HTTPRequestOptions } from '../interfaces';
 
 function parseHeaders(headerString: string) {
   return headerString

--- a/ember-file-upload/src/system/upload-file-reader.ts
+++ b/ember-file-upload/src/system/upload-file-reader.ts
@@ -4,8 +4,7 @@ import RSVP from 'rsvp';
   Provides a promise-aware interface for reading files.
 
   ```js
-  import UploadFile from 'ember-file-upload/upload-file';
-  import UploadFileReader from 'ember-file-upload/system/file-reader';
+  import { UploadFile, UploadFileReader } from 'ember-file-upload';
 
   let reader = new UploadFileReader();
   let file = File.fromDataURL('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAACNJREFUCB1jYICC6dOn/4exwTRMAEYzwBnoOmASMBpuDLIAAIVVFiE0cg0oAAAAAElFTkSuQmCC');

--- a/ember-file-upload/src/system/upload.ts
+++ b/ember-file-upload/src/system/upload.ts
@@ -2,8 +2,8 @@ import { assert } from '@ember/debug';
 import HTTPRequest from './http-request';
 import RSVP from 'rsvp';
 import { waitForPromise } from '@ember/test-waiters';
-import type UploadFile from 'ember-file-upload/upload-file';
-import { FileState, UploadOptions } from 'ember-file-upload/interfaces';
+import type UploadFile from '../upload-file';
+import { FileState, UploadOptions } from '../interfaces';
 
 function clone(object: object | undefined) {
   return object ? { ...object } : {};

--- a/ember-file-upload/src/upload-file.ts
+++ b/ember-file-upload/src/upload-file.ts
@@ -7,11 +7,7 @@ import UploadFileReader from './system/upload-file-reader';
 import Queue from './queue';
 import { guidFor } from '@ember/object/internals';
 import RSVP from 'rsvp';
-import {
-  FileSource,
-  FileState,
-  UploadOptions,
-} from 'ember-file-upload/interfaces';
+import { FileSource, FileState, UploadOptions } from './interfaces';
 
 /**
  * Files provide a uniform interface for interacting

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test-app"
   ],
   "scripts": {
-    "prepare": "yarn workspace ember-file-upload prepare"
+    "prepare": "yarn workspace ember-file-upload prepare",
+    "test": "yarn workspace test-app test:ember -s"
   },
   "repository": "https://github.com/adopted-ember-addons/ember-file-upload",
   "resolutions": {

--- a/test-app/mirage/config.js
+++ b/test-app/mirage/config.js
@@ -1,4 +1,4 @@
-import { upload } from 'ember-file-upload/mirage';
+import { uploadHandler } from 'ember-file-upload';
 import { discoverEmberDataModels } from 'ember-cli-mirage';
 import { createServer } from 'miragejs';
 
@@ -9,7 +9,7 @@ export default function (config) {
     routes() {
       this.post(
         '/photos/new',
-        upload(function (db, request) {
+        uploadHandler(function (db, request) {
           let { type, name, size, url } = request.requestBody.file;
           return db.create('photo', {
             filename: name,

--- a/test-app/tests/helpers/file-queue-helper-test.js
+++ b/test-app/tests/helpers/file-queue-helper-test.js
@@ -2,9 +2,8 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, settled, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { DEFAULT_QUEUE, FileState } from 'ember-file-upload';
 import { selectFiles } from 'ember-file-upload/test-support';
-import { DEFAULT_QUEUE } from 'ember-file-upload/services/file-queue';
-import { FileState } from 'ember-file-upload/interfaces';
 import { later } from '@ember/runloop';
 
 

--- a/test-app/tests/integration/components/file-dropzone-test.js
+++ b/test-app/tests/integration/components/file-dropzone-test.js
@@ -7,7 +7,7 @@ import {
   dragEnter,
   dragLeave,
 } from 'ember-file-upload/test-support';
-import Queue from 'ember-file-upload/queue';
+import { Queue } from 'ember-file-upload';
 
 module('Integration | Component | FileDropzone', function (hooks) {
   setupRenderingTest(hooks);

--- a/test-app/tests/integration/components/mirage-handler-test.js
+++ b/test-app/tests/integration/components/mirage-handler-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { upload as uploadHandler } from 'ember-file-upload/mirage';
+import { uploadHandler } from 'ember-file-upload';
 import { selectFiles } from 'ember-file-upload/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { animatedGif, staticGif, mp4, ogg, png } from '../../utils/file-data';

--- a/test-app/tests/integration/services/file-queue-test.js
+++ b/test-app/tests/integration/services/file-queue-test.js
@@ -2,8 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import UploadFile from 'ember-file-upload/upload-file';
-import { FileSource } from 'ember-file-upload/interfaces';
+import { UploadFile, FileSource } from 'ember-file-upload';
 
 module('Integration | Service | file queue', function (hooks) {
   setupRenderingTest(hooks);

--- a/test-app/tests/unit/services/file-queue-test.js
+++ b/test-app/tests/unit/services/file-queue-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import UploadFile from 'ember-file-upload/upload-file';
+import { UploadFile } from 'ember-file-upload';
 
 module('Unit | Service | file-queue', function (hooks) {
   setupTest(hooks);

--- a/test-app/tests/unit/system/data-transfer-wrapper-test.js
+++ b/test-app/tests/unit/system/data-transfer-wrapper-test.js
@@ -1,4 +1,4 @@
-import DataTransferWrapper from 'ember-file-upload/system/data-transfer-wrapper';
+import { DataTransferWrapper } from 'ember-file-upload';
 import { module, test } from 'qunit';
 
 module('Unit | DataTransferWrapper', function (hooks) {

--- a/test-app/tests/unit/system/data-transfer-wrapper-test.js
+++ b/test-app/tests/unit/system/data-transfer-wrapper-test.js
@@ -1,4 +1,4 @@
-import { DataTransferWrapper } from 'ember-file-upload';
+import { DataTransferWrapper } from 'ember-file-upload/internal';
 import { module, test } from 'qunit';
 
 module('Unit | DataTransferWrapper', function (hooks) {

--- a/test-app/tests/unit/system/http-request-test.js
+++ b/test-app/tests/unit/system/http-request-test.js
@@ -1,5 +1,5 @@
 import FakeXMLHttpRequest from 'fake-xml-http-request';
-import HttpRequest from 'ember-file-upload/system/http-request';
+import { HTTPRequest } from 'ember-file-upload';
 import { module, test, skip } from 'qunit';
 
 module('Unit | HttpRequest', function (hooks) {
@@ -14,7 +14,7 @@ module('Unit | HttpRequest', function (hooks) {
       };
       return request;
     };
-    this.subject = new HttpRequest();
+    this.subject = new HTTPRequest();
   });
 
   hooks.afterEach(function () {
@@ -192,7 +192,7 @@ module('Unit | HttpRequest', function (hooks) {
   });
 
   test(`succesful open with 'withCredentials: true'`, function (assert) {
-    this.subject = new HttpRequest({ withCredentials: true });
+    this.subject = new HTTPRequest({ withCredentials: true });
     this.subject.open('POST', 'http://emberjs.com');
 
     assert.true(this.request.withCredentials);

--- a/test-app/tests/unit/system/http-request-test.js
+++ b/test-app/tests/unit/system/http-request-test.js
@@ -1,5 +1,5 @@
 import FakeXMLHttpRequest from 'fake-xml-http-request';
-import { HTTPRequest } from 'ember-file-upload';
+import { HTTPRequest } from 'ember-file-upload/internal';
 import { module, test, skip } from 'qunit';
 
 module('Unit | HttpRequest', function (hooks) {

--- a/test-app/tests/unit/system/upload-file-reader-test.js
+++ b/test-app/tests/unit/system/upload-file-reader-test.js
@@ -1,4 +1,4 @@
-import { UploadFileReader } from 'ember-file-upload';
+import { UploadFileReader } from 'ember-file-upload/internal';
 import { module, test } from 'qunit';
 
 const FakeFileReader = {

--- a/test-app/tests/unit/system/upload-file-reader-test.js
+++ b/test-app/tests/unit/system/upload-file-reader-test.js
@@ -1,4 +1,4 @@
-import UploadFileReader from 'ember-file-upload/system/upload-file-reader';
+import { UploadFileReader } from 'ember-file-upload';
 import { module, test } from 'qunit';
 
 const FakeFileReader = {

--- a/test-app/tests/unit/upload-file-test.js
+++ b/test-app/tests/unit/upload-file-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { upload as uploadHandler } from 'ember-file-upload/mirage';
+import { uploadHandler } from 'ember-file-upload';
 import { UploadFile, FileSource } from 'ember-file-upload';
 
 module('Unit | UploadFile', function (hooks) {

--- a/test-app/tests/unit/upload-file-test.js
+++ b/test-app/tests/unit/upload-file-test.js
@@ -2,8 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { upload as uploadHandler } from 'ember-file-upload/mirage';
-import UploadFile from 'ember-file-upload/upload-file';
-import { FileSource } from 'ember-file-upload/interfaces';
+import { UploadFile, FileSource } from 'ember-file-upload';
 
 module('Unit | UploadFile', function (hooks) {
   setupTest(hooks);


### PR DESCRIPTION
Updates the public API of all exported modules to be named exports from the top level.

Another breaking change but will give us more flexibility in the future to move files around etc.