### PR TITLE
Correct type exports

### DIFF
--- a/ember-file-upload/package.json
+++ b/ember-file-upload/package.json
@@ -135,6 +135,13 @@
     "./test-support": "./dist/test-support.js",
     "./addon-main.js": "./addon-main.js"
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
   "release-it": {
     "plugins": {
       "release-it-lerna-changelog": {

--- a/ember-file-upload/src/components/file-dropzone.ts
+++ b/ember-file-upload/src/components/file-dropzone.ts
@@ -4,8 +4,9 @@ import { getOwner } from '@ember/application';
 import DataTransferWrapper from '../system/data-transfer-wrapper';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import UploadFile from '../upload-file';
-import FileQueueService, { DEFAULT_QUEUE } from '../services/file-queue';
+import { UploadFile } from '../upload-file';
+import type FileQueueService from '../services/file-queue';
+import { DEFAULT_QUEUE } from '../services/file-queue';
 import {
   FileUploadDragEvent,
   FileSource,

--- a/ember-file-upload/src/helpers/file-queue.ts
+++ b/ember-file-upload/src/helpers/file-queue.ts
@@ -1,7 +1,7 @@
 import Helper from '@ember/component/helper';
 import { registerDestructor } from '@ember/destroyable';
 import { inject as service } from '@ember/service';
-import type UploadFile from '../upload-file';
+import type { UploadFile } from '../upload-file';
 import type FileQueueService from '../services/file-queue';
 import { DEFAULT_QUEUE } from '../services/file-queue';
 import { FileQueueArgs, QueueListener } from '../interfaces';

--- a/ember-file-upload/src/index.ts
+++ b/ember-file-upload/src/index.ts
@@ -1,6 +1,6 @@
-import Queue from './queue';
-import UploadFile from './upload-file';
-import uploadHandler from './mirage/upload-handler';
+import { Queue } from './queue';
+import { UploadFile } from './upload-file';
+import { uploadHandler } from './mirage/upload-handler';
 import { FileSource, FileState } from './interfaces';
 import { DEFAULT_QUEUE } from './services/file-queue';
 

--- a/ember-file-upload/src/interfaces.ts
+++ b/ember-file-upload/src/interfaces.ts
@@ -1,5 +1,5 @@
-import type UploadFile from './upload-file';
-import type Queue from './queue';
+import type { UploadFile } from './upload-file';
+import type { Queue } from './queue';
 import type FileQueueService from './services/file-queue';
 import type DataTransferWrapper from './system/data-transfer-wrapper';
 

--- a/ember-file-upload/src/mirage/upload-handler.ts
+++ b/ember-file-upload/src/mirage/upload-handler.ts
@@ -20,7 +20,7 @@ interface FakeRequest {
   };
 }
 
-export default function uploadHandler(
+export function uploadHandler(
   fn: (this: void, db: any, request: FakeRequest) => void,
   options = { network: null, timeout: null }
 ) {

--- a/ember-file-upload/src/queue.ts
+++ b/ember-file-upload/src/queue.ts
@@ -1,8 +1,8 @@
 import { action } from '@ember/object';
 import { modifier } from 'ember-modifier';
 import { TrackedSet } from 'tracked-built-ins';
-import UploadFile from './upload-file';
-import FileQueueService from './services/file-queue';
+import { UploadFile } from './upload-file';
+import type FileQueueService from './services/file-queue';
 import {
   FileSource,
   FileState,
@@ -19,7 +19,7 @@ import {
  * of uploads when a user navigates around your
  * application.
  */
-export default class Queue {
+export class Queue {
   #listeners: Set<QueueListener> = new Set();
 
   #name: QueueName;

--- a/ember-file-upload/src/services/file-queue.ts
+++ b/ember-file-upload/src/services/file-queue.ts
@@ -1,8 +1,8 @@
 import { assert } from '@ember/debug';
 import Service from '@ember/service';
 import { registerDestructor } from '@ember/destroyable';
-import Queue from '../queue';
-import type UploadFile from '../upload-file';
+import { Queue } from '../queue';
+import type { UploadFile } from '../upload-file';
 import { QueueName } from '../interfaces';
 import { TrackedMap } from 'tracked-built-ins';
 

--- a/ember-file-upload/src/system/upload.ts
+++ b/ember-file-upload/src/system/upload.ts
@@ -2,7 +2,7 @@ import { assert } from '@ember/debug';
 import HTTPRequest from './http-request';
 import RSVP from 'rsvp';
 import { waitForPromise } from '@ember/test-waiters';
-import type UploadFile from '../upload-file';
+import type { UploadFile } from '../upload-file';
 import { FileState, UploadOptions } from '../interfaces';
 
 function clone(object: object | undefined) {

--- a/ember-file-upload/src/upload-file.ts
+++ b/ember-file-upload/src/upload-file.ts
@@ -4,7 +4,7 @@ import { upload } from './system/upload';
 import HTTPRequest from './system/http-request';
 import UploadFileReader from './system/upload-file-reader';
 
-import Queue from './queue';
+import type { Queue } from './queue';
 import { guidFor } from '@ember/object/internals';
 import RSVP from 'rsvp';
 import { FileSource, FileState, UploadOptions } from './interfaces';
@@ -13,7 +13,7 @@ import { FileSource, FileState, UploadOptions } from './interfaces';
  * Files provide a uniform interface for interacting
  * with data that can be uploaded or read.
  */
-export default class UploadFile {
+export class UploadFile {
   file: File;
   #source: FileSource;
 


### PR DESCRIPTION
Reported in #807

Unfortunately this issue doesn't show up in test builds since our test app doesn't use ts. Will need to consider a TypeScript testing strategy 🤔 

Was able to repro the issue by creating ember app and installing `ember-cli-typescript`.

Corrected type exports by named (rather than default) exporting all public modules. Corrected a few instances where a full module was imported where only its type signature was used.

Also added a missing `typesVersions` field to `package.json`.

I'm not very experienced with TypeScript or publishing types  but this does fix all issues with the repro I created.