### PR TITLE
HttpRequest: Allow empty string as body (204 Response)

### DIFF
--- a/ember-file-upload/src/system/http-request.ts
+++ b/ember-file-upload/src/system/http-request.ts
@@ -16,7 +16,8 @@ function parseHeaders(headerString: string) {
 }
 
 function parseResponse(request: XMLHttpRequest): Response {
-  return new Response(request.response, {
+  const body = request.response === '' ? null : request.response;
+  return new Response(body, {
     status: request.status,
     statusText: request.statusText,
     headers: parseHeaders(request.getAllResponseHeaders()),

--- a/test-app/tests/unit/system/http-request-test.js
+++ b/test-app/tests/unit/system/http-request-test.js
@@ -224,6 +224,27 @@ module('Unit | HttpRequest', function (hooks) {
     );
   });
 
+  // Check for regression of: https://github.com/adopted-ember-addons/ember-file-upload/issues/809
+  test('regression: successful send with a 204 and empty string response body', function (assert) {
+    assert.expect(2);
+    this.subject.open('PUT', 'http://emberjs.com');
+    let promise = this.subject
+      .send({
+        filename: 'rfc.md',
+      })
+      .then(function (response) {
+        assert.strictEqual(response.status, 204, 'status is 204');
+        return response.text();
+      })
+      .then((responeText) => {
+        assert.strictEqual(responeText, '', 'response text matches');
+      });
+
+    this.respond(204, { 'Content-Type': 'text/plain' }, '');
+
+    return promise;
+  });
+
   skip('onprogress', function () {});
 
   skip('ontimeout', function () {});


### PR DESCRIPTION
Reported in #809

Reproduced and patched through a regression test.