### PR TITLE
feat: add option to allow dropping a directory and reading the contents

### DIFF
--- a/ember-file-upload/src/components/file-dropzone.ts
+++ b/ember-file-upload/src/components/file-dropzone.ts
@@ -65,6 +65,10 @@ export default class FileDropzoneComponent extends Component<FileDropzoneArgs> {
     return this.args.multiple ?? true;
   }
 
+  get allowFolderDrop() {
+    return this.args.allowFolderDrop ?? false;
+  }
+
   get files(): File[] {
     const files = this.dataTransferWrapper?.files ?? [];
     if (this.multiple) return files;
@@ -132,7 +136,7 @@ export default class FileDropzoneComponent extends Component<FileDropzoneArgs> {
   }
 
   @action
-  didDrop(event: FileUploadDragEvent) {
+  async didDrop(event: FileUploadDragEvent) {
     if (this.dataTransferWrapper) {
       this.dataTransferWrapper.dataTransfer = event.dataTransfer;
     }
@@ -217,7 +221,14 @@ export default class FileDropzoneComponent extends Component<FileDropzoneArgs> {
     // }
 
     if (this.dataTransferWrapper) {
-      const addedFiles = this.addFiles(this.files);
+      let files;
+      if (this.allowFolderDrop) {
+        files = await this.dataTransferWrapper.getFilesAndDirectories();
+      } else {
+        files = this.files;
+      }
+
+      const addedFiles = this.addFiles(files);
       this.args.onDrop?.(addedFiles, this.dataTransferWrapper);
 
       this.active = false;

--- a/ember-file-upload/src/interfaces.ts
+++ b/ember-file-upload/src/interfaces.ts
@@ -105,6 +105,13 @@ export interface FileDropzoneArgs {
   allowUploadsFromWebsites?: boolean;
 
   /**
+   *
+   *
+   * @defaulValue false
+   * */
+  allowFolderDrop?: boolean;
+
+  /**
    * This is the type of cursor that should
    * be shown when a drag event happens.
    *

--- a/ember-file-upload/src/system/data-transfer-wrapper.ts
+++ b/ember-file-upload/src/system/data-transfer-wrapper.ts
@@ -43,6 +43,69 @@ export default class DataTransferWrapper {
     return this.files.length ? this.files : this.items;
   }
 
+  async getFilesAndDirectories() {
+    const files: File[] = [];
+
+    const readEntry = async (entry: FileSystemEntry): Promise<File> => {
+      return new Promise((resolve, reject) => {
+        if (entry.isFile) {
+          (entry as FileSystemFileEntry).file((fileEntry: File) => {
+            resolve(fileEntry);
+          });
+        } else {
+          reject('Directory contains nested directories');
+        }
+      });
+    };
+
+    const readAllFilesInDirectory = (item: DataTransferItem): Promise<File[]> =>
+      new Promise((resolve) => {
+        (item.webkitGetAsEntry() as FileSystemDirectoryEntry)
+          ?.createReader()
+          ?.readEntries(async (entries: FileSystemEntry[]) => {
+            const readFiles: File[] = await Promise.all(
+              entries.map(readEntry)
+            ).catch((err) => {
+              throw err;
+            });
+            resolve(readFiles.filter((file) => file !== undefined) as File[]);
+          });
+      });
+
+    const readDataTransferItem = async (
+      item: DataTransferItem
+    ): Promise<File[]> => {
+      if (item.webkitGetAsEntry()?.isDirectory) {
+        const directoryFile = item.getAsFile() as File;
+        const filesInDirectory: File[] = await readAllFilesInDirectory(item);
+        return [directoryFile, ...filesInDirectory];
+      } else {
+        const fileItem = item.getAsFile() as File;
+        return [fileItem];
+      }
+    };
+
+    if (this.dataTransfer?.items) {
+      const allFilesInDataTransferItems: File[][] = await Promise.all(
+        Array.from(this.dataTransfer?.items).map(readDataTransferItem)
+      );
+
+      const flattenedFileArray: File[] = allFilesInDataTransferItems.reduce(
+        (flattenedList, fileList) => {
+          return [...flattenedList, ...fileList];
+        },
+        []
+      );
+
+      files.push(...flattenedFileArray);
+    } else {
+      const droppedFiles: File[] = Array.from(this.dataTransfer?.files ?? []);
+      files.push(...droppedFiles);
+    }
+
+    return files;
+  }
+
   get files() {
     return Array.from(this.dataTransfer?.files ?? []);
   }

--- a/test-app/app/components/demo-upload.hbs
+++ b/test-app/app/components/demo-upload.hbs
@@ -1,6 +1,6 @@
 {{#let (file-queue name="photos" onFileAdded=this.uploadProof) as |queue|}}
   <div class="docs-my-8 text-center">
-    <FileDropzone @queue={{queue}} class="demo-dropzone" as |dropzone|>
+    <FileDropzone @queue={{queue}} @allowFolderDrop={{@allowFolderDrop}} class="demo-dropzone" as |dropzone|>
       <div class="dropzone-upload-area upload {{if dropzone.active "active"}}">
         {{#if dropzone.supported}}
           <div class="emoji mb-16">

--- a/test-app/tests/unit/system/data-transfer-wrapper-test.js
+++ b/test-app/tests/unit/system/data-transfer-wrapper-test.js
@@ -66,4 +66,37 @@ module('Unit | DataTransferWrapper', function (hooks) {
     };
     assert.strictEqual(this.subject.filesOrItems.length, 2);
   });
+
+  test('directory dropped', async function (assert) {
+    const transfer = {
+      items: [
+        folderItem('directory-name', [
+          new File([], 'fileName.txt'),
+          new File([], 'otherFileName.txt'),
+        ]),
+      ],
+    };
+    this.subject.dataTransfer = transfer;
+    assert.strictEqual((await this.subject.getFilesAndDirectories()).length, 3);
+  });
+
+  const folderItem = (folderName, filesInDirectory) => ({
+    webkitGetAsEntry: () => ({
+      isDirectory: true,
+      createReader: () => ({
+        readEntries: (callback) => {
+          const entryFiles = filesInDirectory.map((file) => {
+            return {
+              isFile: true,
+              file: (callback) => {
+                callback(file);
+              },
+            };
+          });
+          callback(entryFiles);
+        },
+      }),
+    }),
+    getAsFile: () => new File([], folderName, { type: '' }),
+  });
 });


### PR DESCRIPTION
This is an attempt at resolving https://github.com/adopted-ember-addons/ember-file-upload/issues/2 , to support dropping folders.

We needed this for one of our clients, so I tried to add the option. It's a bit convoluted but the whole File and Directories web API is not so easy to use. Definitely open for ideas (and suggestions for better testing / documentation), but it would be great if we could add this to the package, for now we're publishing and using a forked version which works but is not ideal.

It also does use the non-standard `webkitGetAsEntry` file api but as said in this comment it is widely supported:
https://github.com/adopted-ember-addons/ember-file-upload/issues/2#issuecomment-1082435129
https://caniuse.com/?search=webkitGetAsEntry