### PR TITLE
UploadHandler – use `unknown` type for Mirage DB

### DIFF
--- a/ember-file-upload/src/mirage/upload-handler.ts
+++ b/ember-file-upload/src/mirage/upload-handler.ts
@@ -25,7 +25,7 @@ interface FakeRequest {
 }
 
 export function uploadHandler(
-  fn: (this: void, db: any, request: FakeRequest) => void,
+  fn: (this: void, db: unknown, request: FakeRequest) => void,
   options = { network: null, timeout: null }
 ) {
   if (
@@ -34,8 +34,9 @@ export function uploadHandler(
         dependencySatisfies('ember-cli-mirage', '*')
     )
   ) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { Response } = importSync('miragejs') as { Response: any };
-    return function (db: any, request: FakeRequest) {
+    return function (db: unknown, request: FakeRequest) {
       let speed = Infinity;
 
       if (options.network && NETWORK[options.network]) {


### PR DESCRIPTION
Also disable eslint warning for `any` type.

Chore to tidy up build warnings.