### PR TITLE
Revert @ember/test-helpers update and pin to 2.7.0

### DIFF
--- a/ember-file-upload/package.json
+++ b/ember-file-upload/package.json
@@ -46,7 +46,7 @@
     "prepare": "yarn build"
   },
   "dependencies": {
-    "@ember/test-helpers": "^2.9.3",
+    "@ember/test-helpers": "~2.7.0",
     "@ember/test-waiters": "^3.0.0",
     "@embroider/addon-shim": "^1.5.0",
     "@embroider/macros": "^1.0.0",
@@ -74,6 +74,7 @@
     "@types/ember__string": "^3.16.3",
     "@types/ember__template": "^4.0.0",
     "@types/ember__test": "^4.0.0",
+    "@types/ember__test-helpers": "~2.6.0",
     "@types/ember__utils": "^4.0.0",
     "@types/rsvp": "^4.0.4",
     "@typescript-eslint/eslint-plugin": "^5.6.0",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@babel/core": "^7.19.6",
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.9.3",
+    "@ember/test-helpers": "~2.7.0",
     "@embroider/test-setup": "^2.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/website/package.json
+++ b/website/package.json
@@ -27,7 +27,7 @@
     "@babel/eslint-parser": "^7.16.5",
     "@docfy/ember": "^0.5.0",
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.9.3",
+    "@ember/test-helpers": "~2.7.0",
     "@embroider/macros": "^1.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,18 +1089,16 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
-"@ember/test-helpers@^2.9.3":
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.9.3.tgz#c2a9d6ab1c367af92cf1a334f97eb19b8e06e6e1"
-  integrity sha512-ejVg4Dj+G/6zyLvQsYOvmGiOLU6AS94tY4ClaO1E2oVvjjtVJIRmVLFN61I+DuyBg9hS3cFoPjQRTZB9MRIbxQ==
+"@ember/test-helpers@~2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.7.0.tgz#d8e08b614cdd5eac647689d655e78e1de725f474"
+  integrity sha512-eWFtw5+sbci1Fw+E+HoyaMxY126LvK7jul6i8tad48zlWoxrOalbhJhz1mKqIo4daHbqIZWuFgQhOib4QfTKCQ==
   dependencies:
     "@ember/test-waiters" "^3.0.0"
-    "@embroider/macros" "^1.10.0"
-    "@embroider/util" "^1.9.0"
     broccoli-debug "^0.6.5"
     broccoli-funnel "^3.0.8"
-    ember-cli-babel "^7.26.11"
-    ember-cli-htmlbars "^6.1.1"
+    ember-cli-babel "^7.26.6"
+    ember-cli-htmlbars "^5.7.1"
     ember-destroyable-polyfill "^2.0.3"
 
 "@ember/test-waiters@^3.0.0":
@@ -1172,7 +1170,7 @@
     typescript-memoize "^1.0.1"
     walk-sync "^3.0.0"
 
-"@embroider/macros@1.10.0", "@embroider/macros@^0.41.0", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.10.0", "@embroider/macros@^1.5.0", "@embroider/macros@^1.9.0":
+"@embroider/macros@1.10.0", "@embroider/macros@^0.41.0", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.5.0", "@embroider/macros@^1.9.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.10.0.tgz#af3844d5db48f001b85cfb096c76727c72ad6c1e"
   integrity sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==
@@ -1208,7 +1206,7 @@
     lodash "^4.17.21"
     resolve "^1.20.0"
 
-"@embroider/util@^1.5.0", "@embroider/util@^1.9.0":
+"@embroider/util@^1.5.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@embroider/util/-/util-1.9.0.tgz#331c46bdf106c44cb1dd6baaa9030d322c13cfca"
   integrity sha512-9I63iJK6N01OHJafmS/BX0msUkTlmhFMIEmDl/SRNACVi0nS6QfNyTgTTeji1P/DALf6eobg/9t/N4VhS9G9QA==
@@ -1779,6 +1777,14 @@
   dependencies:
     "@types/ms" "*"
 
+"@types/ember-resolver@*":
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/@types/ember-resolver/-/ember-resolver-5.0.13.tgz#db66678076ca625ed80b629c09619ae85c1c1f7a"
+  integrity sha512-pO964cAPhAaFJoS28M8+b5MzAhQ/tVuNM4GDUIAexheQat36axG2WTG8LQ5ea07MSFPesrRFk2T3z88pfvdYKA==
+  dependencies:
+    "@types/ember__object" "*"
+    "@types/ember__owner" "*"
+
 "@types/ember@*":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/ember/-/ember-4.0.3.tgz#dde52a88e3b41eb73c80063ddfad35f751893e32"
@@ -1925,6 +1931,29 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/ember__template/-/ember__template-4.0.1.tgz#aba59c22fbd1fcfc731eaf97ee8ee784e8c5e9db"
   integrity sha512-hAxzdJa0zNvZSoHoCbtd0KGt6Dls4Aph9EwdtbUcdnlMiSUtEDUdKTtDbUrysqJjxGBr4vWIdJEqWtZ0/Y8KBw==
+
+"@types/ember__test-helpers@*":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@types/ember__test-helpers/-/ember__test-helpers-2.8.2.tgz#59ca672c152ff9044b4f4b9eeb66fc847e0f853a"
+  integrity sha512-Ho3TTcnbjdQO9UvLwoswRMpCR2j7X6T8qSOaKehnST9s15ACb4MXHwec1NhmpCOhdvBRREYfG3YbduNeXoITMg==
+  dependencies:
+    "@types/ember-resolver" "*"
+    "@types/ember__application" "*"
+    "@types/ember__error" "*"
+    "@types/ember__owner" "*"
+    "@types/ember__test-helpers" "*"
+    "@types/htmlbars-inline-precompile" "*"
+
+"@types/ember__test-helpers@~2.6.0":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@types/ember__test-helpers/-/ember__test-helpers-2.6.1.tgz#2835bc60fd7daa93292d669fa9b61706836fe2e7"
+  integrity sha512-d2RShuBSaBzp04nt8ad+mNE1F6rbIcIIud8WFUVQqGSUGHuZQUq1051Jza12ksCUnXduyE/J9UDjyZvNKOHeBQ==
+  dependencies:
+    "@types/ember-resolver" "*"
+    "@types/ember__application" "*"
+    "@types/ember__error" "*"
+    "@types/ember__test-helpers" "*"
+    "@types/htmlbars-inline-precompile" "*"
 
 "@types/ember__test@*", "@types/ember__test@^4.0.0":
   version "4.0.1"


### PR DESCRIPTION
Temporary measure.

Don't really want to release while this dependency is pinned with a `~` as this is a declared dependency of the included test helpers.

But also uncomfortable with the CI failing for ember 3.28.

Reference:
emberjs/ember-test-helpers/issues/1232
