### PR TITLE
support ember-modifier v4

### DIFF
--- a/ember-file-upload/package.json
+++ b/ember-file-upload/package.json
@@ -73,6 +73,7 @@
     "@types/ember__destroyable": "^4.0.0",
     "@types/ember__engine": "^4.0.0",
     "@types/ember__object": "^4.0.0",
+    "@types/ember__owner": "^4.0.0",
     "@types/ember__runloop": "^4.0.0",
     "@types/ember__service": "^4.0.0",
     "@types/ember__string": "^3.16.3",

--- a/ember-file-upload/package.json
+++ b/ember-file-upload/package.json
@@ -53,7 +53,7 @@
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "ember-auto-import": "^2.0.0",
-    "ember-modifier": "^3.2.7",
+    "ember-modifier": "^3.2.7 || ^4.0.0",
     "tracked-built-ins": "^3.0.0"
   },
   "devDependencies": {

--- a/ember-file-upload/src/interfaces.ts
+++ b/ember-file-upload/src/interfaces.ts
@@ -82,16 +82,6 @@ export enum FileSource {
   Blob = 'blob',
 }
 
-export interface SelectFileModifierSignature {
-  Args: {
-    Named: {
-      filter?: (file: File, files: File[], index: number) => boolean;
-      onFilesSelected?: (files: UploadFile[]) => void;
-    };
-  };
-  Element: HTMLInputElement;
-}
-
 export interface FileDropzoneArgs {
   queue?: Queue;
 

--- a/ember-file-upload/src/queue.ts
+++ b/ember-file-upload/src/queue.ts
@@ -230,7 +230,7 @@ export class Queue {
         element.removeEventListener('change', changeHandler);
       };
     },
-    // ember-modifier@^3 requires an options hash as second argument
+    // @ts-expect-error ember-modifier@^3 requires an options hash as second argument
     // used to opt-in to lazy argument handling, which is the default for ember-modifier@^4
     { eager: false }
   );

--- a/ember-file-upload/src/queue.ts
+++ b/ember-file-upload/src/queue.ts
@@ -3,12 +3,7 @@ import { modifier } from 'ember-modifier';
 import { TrackedSet } from 'tracked-built-ins';
 import { UploadFile } from './upload-file';
 import type FileQueueService from './services/file-queue';
-import {
-  FileSource,
-  FileState,
-  QueueListener,
-  QueueName,
-} from './interfaces';
+import { FileSource, FileState, QueueListener, QueueName } from './interfaces';
 
 /**
  * The Queue is a collection of files that
@@ -181,10 +176,17 @@ export class Queue {
   }
 
   selectFile = modifier(
-    (element: HTMLInputElement, _positional: [], { filter, onFilesSelected }: {
-      filter?: (file: File, files: File[], index: number) => boolean;
-      onFilesSelected?: (files: UploadFile[]) => void;
-    }) => {
+    (
+      element: HTMLInputElement,
+      _positional: [],
+      {
+        filter,
+        onFilesSelected,
+      }: {
+        filter?: (file: File, files: File[], index: number) => boolean;
+        onFilesSelected?: (files: UploadFile[]) => void;
+      }
+    ) => {
       const changeHandler = (event: Event) => {
         const { files: fileList } = event.target as HTMLInputElement;
         if (!fileList) {

--- a/ember-file-upload/src/queue.ts
+++ b/ember-file-upload/src/queue.ts
@@ -8,7 +8,6 @@ import {
   FileState,
   QueueListener,
   QueueName,
-  SelectFileModifierSignature,
 } from './interfaces';
 
 /**
@@ -181,8 +180,11 @@ export class Queue {
     }
   }
 
-  selectFile = modifier<SelectFileModifierSignature>(
-    (element, _positional, { filter, onFilesSelected }) => {
+  selectFile = modifier(
+    (element: HTMLInputElement, _positional: [], { filter, onFilesSelected }: {
+      filter?: (file: File, files: File[], index: number) => boolean;
+      onFilesSelected?: (files: UploadFile[]) => void;
+    }) => {
       const changeHandler = (event: Event) => {
         const { files: fileList } = event.target as HTMLInputElement;
         if (!fileList) {

--- a/ember-file-upload/src/queue.ts
+++ b/ember-file-upload/src/queue.ts
@@ -230,7 +230,7 @@ export class Queue {
         element.removeEventListener('change', changeHandler);
       };
     },
-    // @ts-expect-error: ember-modifier@^3 requires an options hash as second argument
+    // ember-modifier@^3 requires an options hash as second argument
     // used to opt-in to lazy argument handling, which is the default for ember-modifier@^4
     { eager: false }
   );

--- a/ember-file-upload/src/queue.ts
+++ b/ember-file-upload/src/queue.ts
@@ -230,6 +230,8 @@ export class Queue {
         element.removeEventListener('change', changeHandler);
       };
     },
+    // @ts-expect-error: ember-modifier@^3 requires an options hash as second argument
+    // used to opt-in to lazy argument handling, which is the default for ember-modifier@^4
     { eager: false }
   );
 }

--- a/ember-file-upload/src/system/drag-listener-modifier.ts
+++ b/ember-file-upload/src/system/drag-listener-modifier.ts
@@ -2,6 +2,7 @@ import Modifier, { ArgsFor, NamedArgs } from 'ember-modifier';
 import { DragListenerModifierSignature } from '../interfaces';
 import DragListener from './drag-listener';
 import { registerDestructor } from '@ember/destroyable';
+import type Owner from '@ember/owner';
 
 function cleanup(instance: DragListenerModifier) {
   if (!instance.listener) return;
@@ -12,7 +13,7 @@ function cleanup(instance: DragListenerModifier) {
 export default class DragListenerModifier extends Modifier<DragListenerModifierSignature> {
   listener?: DragListener;
 
-  constructor(owner: unknown, args: ArgsFor<DragListenerModifierSignature>) {
+  constructor(owner: Owner, args: ArgsFor<DragListenerModifierSignature>) {
     super(owner, args);
     registerDestructor(this, cleanup);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
       '@glimmer/component': 1.1.2_@babel+core@7.20.12
       '@glimmer/tracking': 1.1.2
       ember-auto-import: 2.5.0_webpack@5.75.0
-      ember-modifier: 3.2.7_@babel+core@7.20.12
+      ember-modifier: 4.0.0_ember-source@4.8.4
       tracked-built-ins: 3.1.0
     devDependencies:
       '@babel/core': 7.20.12
@@ -6219,17 +6219,20 @@ packages:
       - supports-color
     dev: true
 
-  /ember-modifier/3.2.7_@babel+core@7.20.12:
-    resolution: {integrity: sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==}
-    engines: {node: 12.* || >= 14}
+  /ember-modifier/4.0.0_ember-source@4.8.4:
+    resolution: {integrity: sha512-OdconmrqKP2haK4kBwNmtnA2NiC2MFmIJC3LgJ1WhwZ49GaktM+bRIuFxF/S5W0oaegzKs1qH2ZDlqMeO2L3nw==}
+    engines: {node: 14.* || 16.* || >= 18}
+    peerDependencies:
+      ember-source: '*'
+    peerDependenciesMeta:
+      ember-source:
+        optional: true
     dependencies:
-      ember-cli-babel: 7.26.11
+      '@embroider/addon-shim': 1.8.4
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-cli-typescript: 5.2.1
-      ember-compatibility-helpers: 1.2.6_@babel+core@7.20.12
+      ember-source: 4.8.4_ipwtokbwlukr3yko7oz5lbj6xy
     transitivePeerDependencies:
-      - '@babel/core'
       - supports-color
 
   /ember-page-title/7.0.0:
@@ -14300,7 +14303,7 @@ packages:
       '@glimmer/tracking': 1.1.2
       ember-auto-import: 2.5.0_webpack@5.75.0
       ember-cli-mirage: 2.4.0_7rsiotbptge5bdp46rto6capma
-      ember-modifier: 3.2.7_@babel+core@7.20.12
+      ember-modifier: 4.0.0_ember-source@4.8.4
       miragejs: 0.1.47
       tracked-built-ins: 3.1.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
       babel-eslint: ^10.1.0
       ember-auto-import: ^2.0.0
       ember-cli-htmlbars: ^6.1.1
-      ember-modifier: ^3.2.7
+      ember-modifier: ^3.2.7 || ^4.0.0
       ember-source: ~4.8.0
       ember-template-lint: ^5.0.0
       eslint: ^7.32.0
@@ -14279,7 +14279,7 @@ packages:
     resolution: {directory: ember-file-upload, type: directory}
     id: file:ember-file-upload
     name: ember-file-upload
-    version: 7.1.0
+    version: 7.1.1
     engines: {node: 14.* || 16.* || >= 18}
     peerDependencies:
       ember-cli-mirage: '*'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ importers:
       '@types/ember__destroyable': ^4.0.0
       '@types/ember__engine': ^4.0.0
       '@types/ember__object': ^4.0.0
+      '@types/ember__owner': ^4.0.0
       '@types/ember__runloop': ^4.0.0
       '@types/ember__service': ^4.0.0
       '@types/ember__string': ^3.16.3
@@ -92,6 +93,7 @@ importers:
       '@types/ember__destroyable': 4.0.1
       '@types/ember__engine': 4.0.4_@babel+core@7.20.12
       '@types/ember__object': 4.0.5_@babel+core@7.20.12
+      '@types/ember__owner': 4.0.3
       '@types/ember__runloop': 4.0.2_@babel+core@7.20.12
       '@types/ember__service': 4.0.2_@babel+core@7.20.12
       '@types/ember__string': 3.16.3


### PR DESCRIPTION
This adds support for ember-modifier v4. ember-modifier v3 is supported in parallel. This eases upgrades for applications, which have an indirect dependency on ember-modifier through several packages like this one.

As ember-modifier v3 is still supported going forward, this is _not_ a breaking change.