### PR TITLE
Add interfaces folder to addon.publicEntrypoints

### DIFF
--- a/ember-file-upload/rollup.config.js
+++ b/ember-file-upload/rollup.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
     addon.publicEntrypoints([
       'components/**/*.ts',
       'helpers/**/*.ts',
+      'interfaces/**/*.ts',
       'services/**/*.ts',
       'index.ts',
       'internal.ts',


### PR DESCRIPTION
In our app, we use TypeScript and import the QueueName interface from 'ember-file-upload/interfaces'

Because it is not added to publicEntrypoints of the V2 addon, the file we import changes to 'ember-file-upload/interfaces-fc8a799a'