### PR TITLE
Issue related to async await for upload 

### DIFF
--- a/ember-file-upload/src/system/http-request.ts
+++ b/ember-file-upload/src/system/http-request.ts
@@ -73,7 +73,7 @@ export default class HTTPRequest {
     };
     this.request.onabort = bind(this, function () {
       this.onabort?.();
-      aborted.resolve();
+      return aborted.resolve();
     });
 
     this.request.onloadstart =
@@ -90,14 +90,14 @@ export default class HTTPRequest {
     this.request.onload = bind(this, function () {
       const response = parseResponse(this.request);
       if (Math.floor(response.status / 200) === 1) {
-        resolve(response);
+        return resolve(response);
       } else {
-        reject(response);
+        return reject(response);
       }
     });
 
     this.request.onerror = bind(this, function () {
-      reject(parseResponse(this.request));
+      return reject(parseResponse(this.request));
     });
 
     Object.defineProperty(this, 'timeout', {
@@ -113,7 +113,7 @@ export default class HTTPRequest {
 
     this.request.ontimeout = bind(this, function () {
       this.ontimeout?.();
-      reject(parseResponse(this.request));
+      return reject(parseResponse(this.request));
     });
   }
 


### PR DESCRIPTION
I noticed that there are missing `return` in some places.

I followed https://ember-file-upload.pages.dev/docs/aws

Which is:

```
  @task({ maxConcurrency: 3, enqueue: true })
  *uploadImage(file) {
    const { product } = this.args;
    const apiResponse = yield fetch('/api/s3_direct');
    const s3Response = yield file.upload(apiResponse.url, {
        data: apiResponse.credentials
      });
    product.url = s3Response.headers.Location;
    yield product.save();
  }
  ```
  
  And this doesn't work on `const s3Response` - not resolving without `return resolve`
  
  Also, in this doc, there should be 
  
  ```
   const apiResponse = yield fetch('/api/s3_direct');
   const apiResponseResult = yield apiResponse.json();
   ```
   
   the same with s3Response but e.g. `yield s3Response.text()` (there could be a parser for XML).
   
   I can update the documentation when this is accepted and merged.