### PR TITLE
Avoid parallel `prepare` script runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "test-app"
   ],
   "scripts": {
-    "prepare": "pnpm --filter ember-file-upload prepare",
     "test": "pnpm --filter test-app test:ember -s",
     "website": "pnpm --filter website start"
   },


### PR DESCRIPTION
Avoids this script running twice after installing packages.