### PR TITLE
Add `onUploadStarted`, `onUploadSucceeded` and `onUploadFailed` to `file-queue` helper

### DIFF
--- a/docs/uploading.md
+++ b/docs/uploading.md
@@ -15,17 +15,13 @@ Bind a [file input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/in
 {{/let}}
 ```
 
-After a file is added to your queue, the `onFileAdded` callback will be called. You may then upload the file to a URL by calling `file.upload()`. This returns a promise that is resolved when the file has finished uploading, or is rejected if the file couldn't be uploaded.
+After a file is added to your queue, the `onFileAdded` callback will be called. You may then upload the file to a URL by calling `file.upload()`. This returns a promise that is resolved when the file has finished uploading.
 
 ```js
 export default class ExampleComponent extends Component {
   @action
   async uploadPhoto(file) {
-    try {
-      const response = await file.upload('/api/images/upload');
-    } catch (error) {
-      file.state = 'aborted';
-    }
+    const response = await file.upload('/api/images/upload');
   }
 }
 ```

--- a/ember-file-upload/src/helpers/file-queue.ts
+++ b/ember-file-upload/src/helpers/file-queue.ts
@@ -54,4 +54,16 @@ export default class FileQueueHelper extends Helper implements QueueListener {
   onFileRemoved(file: UploadFile) {
     this.args.onFileRemoved?.(file);
   }
+
+  onUploadStarted(file: UploadFile) {
+    this.args.onUploadStarted?.(file);
+  }
+
+  onUploadSucceeded(file: UploadFile, response: Response) {
+    this.args.onUploadSucceeded?.(file, response);
+  }
+
+  onUploadFailed(file: UploadFile, response: Response) {
+    this.args.onUploadFailed?.(file, response);
+  }
 }

--- a/ember-file-upload/src/interfaces.ts
+++ b/ember-file-upload/src/interfaces.ts
@@ -7,6 +7,9 @@ export interface FileQueueArgs {
   name?: string;
   onFileAdded?: (file: UploadFile) => void;
   onFileRemoved?: (file: UploadFile) => void;
+  onUploadStarted?: (file: UploadFile) => void;
+  onUploadSucceeded?: (file: UploadFile, response: Response) => void;
+  onUploadFailed?: (file: UploadFile, response: Response) => void;
 }
 
 declare module '@ember/service' {
@@ -18,6 +21,9 @@ declare module '@ember/service' {
 export interface QueueListener {
   onFileAdded?(file: UploadFile): void;
   onFileRemoved?(file: UploadFile): void;
+  onUploadStarted?(file: UploadFile): void;
+  onUploadSucceeded?(file: UploadFile, response: Response): void;
+  onUploadFailed?(file: UploadFile, response: Response): void;
 }
 
 export type QueueName = string | symbol;

--- a/ember-file-upload/src/queue.ts
+++ b/ember-file-upload/src/queue.ts
@@ -152,6 +152,24 @@ export class Queue {
     }
   }
 
+  uploadStarted(file: UploadFile) {
+    for (const listener of this.#listeners) {
+      listener.onUploadStarted?.(file);
+    }
+  }
+
+  uploadSucceeded(file: UploadFile, response: Response) {
+    for (const listener of this.#listeners) {
+      listener.onUploadSucceeded?.(file, response);
+    }
+  }
+
+  uploadFailed(file: UploadFile, response: Response) {
+    for (const listener of this.#listeners) {
+      listener.onUploadFailed?.(file, response);
+    }
+  }
+
   /**
    * Flushes the `files` property if they have settled. This
    * will only flush files when all files have arrived at a terminus

--- a/ember-file-upload/src/system/upload.ts
+++ b/ember-file-upload/src/system/upload.ts
@@ -1,6 +1,5 @@
 import { assert } from '@ember/debug';
 import HTTPRequest from './http-request';
-import RSVP from 'rsvp';
 import { waitForPromise } from '@ember/test-waiters';
 import type { UploadFile } from '../upload-file';
 import { FileState, UploadOptions } from '../interfaces';
@@ -116,7 +115,7 @@ export function upload(
       .catch(function (response) {
         file.state = FileState.Failed;
         file.queue?.uploadFailed(file, response);
-        return RSVP.reject(response);
+        return response;
       })
       .finally(() => file.queue?.flush())
   );

--- a/ember-file-upload/src/upload-file.ts
+++ b/ember-file-upload/src/upload-file.ts
@@ -91,16 +91,7 @@ export class UploadFile {
   /**
    * The current state that the file is in.
    */
-  @tracked private internalState: FileState = FileState.Queued;
-
-  get state() {
-    return this.internalState;
-  }
-
-  set state(value) {
-    this.internalState = value;
-    this.queue?.flush();
-  }
+  @tracked state: FileState = FileState.Queued;
 
   // /**
   //   The source of the file. This is useful

--- a/ember-file-upload/src/upload-file.ts
+++ b/ember-file-upload/src/upload-file.ts
@@ -151,6 +151,7 @@ export class UploadFile {
   uploadBinary(url: string, options: UploadOptions) {
     options.contentType = 'application/octet-stream';
     return upload(this, url, options, (request) => {
+      this.queue?.uploadStarted(this);
       return request.send(this.file);
     });
   }
@@ -183,6 +184,7 @@ export class UploadFile {
           }
         }
 
+        this.queue?.uploadStarted(this);
         return request.send(form);
       }
     );

--- a/test-app/tests/helpers/file-queue-helper-test.js
+++ b/test-app/tests/helpers/file-queue-helper-test.js
@@ -126,7 +126,11 @@ module('Integration | Helper | file-queue', function (hooks) {
     this.uploadStarted = (file) => {
       assert.step('upload started');
       assert.strictEqual(file.name, 'dingus.txt', 'file name present');
-      assert.strictEqual(file.state, FileState.Uploading, 'file state present');
+      assert.strictEqual(
+        file.state,
+        FileState.Uploading,
+        'file state is uploading'
+      );
     };
 
     await render(hbs`
@@ -156,7 +160,11 @@ module('Integration | Helper | file-queue', function (hooks) {
     this.uploadSucceeded = (file, response) => {
       assert.step('upload succeeded');
       assert.strictEqual(file.name, 'dingus.txt', 'file name present');
-      assert.strictEqual(file.state, FileState.Uploading, 'file state present');
+      assert.strictEqual(
+        file.state,
+        FileState.Uploaded,
+        'file state is uploaded'
+      );
       assert.strictEqual(response.status, 201, 'response status present');
     };
 
@@ -187,7 +195,7 @@ module('Integration | Helper | file-queue', function (hooks) {
     this.uploadFailed = (file, response) => {
       assert.step('upload failed');
       assert.strictEqual(file.name, 'dingus.txt', 'file name present');
-      assert.strictEqual(file.state, FileState.Uploading, 'file state present');
+      assert.strictEqual(file.state, FileState.Failed, 'file state is failed');
       assert.strictEqual(response.status, 500, 'response status present');
     };
 
@@ -208,7 +216,10 @@ module('Integration | Helper | file-queue', function (hooks) {
   test('files in the queue are autotracked', async function (assert) {
     this.simulateUpload = (file) => {
       file.state = FileState.Uploading;
-      later(() => (file.state = FileState.Uploaded), 100);
+      later(() => {
+        file.state = FileState.Uploaded;
+        file.queue.flush();
+      }, 100);
     };
 
     await render(hbs`

--- a/test-app/tests/unit/services/file-queue-test.js
+++ b/test-app/tests/unit/services/file-queue-test.js
@@ -103,7 +103,7 @@ module('Unit | Service | file-queue', function (hooks) {
     assert.strictEqual(queue.progress, 28);
   });
 
-  test('the queue is emptied when all files are completed', function (assert) {
+  test('the queue is emptied when all files are completed and flush is called', function (assert) {
     var queue = this.owner.lookup('service:file-queue');
     var queue1 = queue.create('queue1');
 
@@ -133,6 +133,7 @@ module('Unit | Service | file-queue', function (hooks) {
     assert.strictEqual(queue.files.length, 3);
 
     file1.state = 'aborted';
+    queue1.flush();
 
     assert.strictEqual(queue.files.length, 0);
     assert.strictEqual(queue1.files.length, 0);


### PR DESCRIPTION
Should fix #58

## Outstanding issues

- [x] (1) At the time that `onUploadSucceeded` and `onUploadFailed` run, the `UploadFile` will have a state of `FileState.Uploading`. Otherwise when state is updated they'll be removed from the queue (queue flushing is triggered by the `state =` setter). We can either document to explain this or make further changes to accommodate it.
  - See comment below for suggestion to address this
- [x] (2) Whether we recommend the user updates `file.state` within these callbacks – depends on how we resolve issue (1). If we do permit updates to `file.state` in these callbacks we'll need to make sure they aren't overwritten by library code
  - Based on discussion I'm hopeful that we won't need to support users setting `file.state` themselves.
  - See comment below for suggestion to address this
- [ ] (3) Update API docs