### PR TITLE
Return `Reponse.error` when status is outside of 200-599 range

### DIFF
--- a/ember-file-upload/src/system/http-request.ts
+++ b/ember-file-upload/src/system/http-request.ts
@@ -17,11 +17,15 @@ function parseHeaders(headerString: string) {
 
 function parseResponse(request: XMLHttpRequest): Response {
   const body = request.response === '' ? null : request.response;
-  return new Response(body, {
-    status: request.status,
-    statusText: request.statusText,
-    headers: parseHeaders(request.getAllResponseHeaders()),
-  });
+  if (request.status >= 200 && request.status < 600) {
+    return new Response(body, {
+      status: request.status,
+      statusText: request.statusText,
+      headers: parseHeaders(request.getAllResponseHeaders()),
+    });
+  } else {
+    return Response.error();
+  }
 }
 
 export default class HTTPRequest {

--- a/test-app/tests/unit/system/http-request-test.js
+++ b/test-app/tests/unit/system/http-request-test.js
@@ -245,6 +245,20 @@ module('Unit | HttpRequest', function (hooks) {
     return promise;
   });
 
+  test('it returns an error response if the response status is ouside of the [200, 599] range', function (assert) {
+    assert.expect(3);
+
+    this.subject.open('PUT', 'http://emberjs.com');
+
+    this.subject.send({ filename: 'rfc.md' }).catch((response) => {
+      assert.strictEqual(response.status, 0, 'response status is 0');
+      assert.false(response.ok, 'response is not ok');
+      assert.strictEqual(response.type, 'error', 'response type is error');
+    });
+
+    this.respond(0, {}, 'timeout');
+  });
+
   skip('onprogress', function () {});
 
   skip('ontimeout', function () {});


### PR DESCRIPTION
Currently we're creating a new [Response](https://github.com/adopted-ember-addons/ember-file-upload/blob/635e3350853e965c5df6a0065a85802b69f5c5e5/ember-file-upload/src/system/http-request.ts#L18-L25) for any response status. However, if the response status is outside of the `200...599` range, this will return an error. See https://developer.mozilla.org/en-US/docs/Web/API/Response for details on the accepted statuses. Also see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status

The reasons for having a status outside of this range could be multiple, like a timeout issue or the server returning a status that does not necessarily comply with common accepted  statuses.

In this PR we're solving this issue by returning a custom Error when the status is outside of this range. The reason we return a custom error is that we want to give users the possibility to consume this error in their apps.

Next steps from here would be to differentiate these exceptions and return custom errors for each, similarly to what Ember Data does. Could be custom errors like `TimeoutError` for timeout for instance. This PR is an improvement nonetheless and can act as a good staring point. Any future improvements in handling these errors could be done independently, outside of this PR.