### PR TITLE
Drop support for node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: '14.x'
+  NODE_VERSION: '16.x'
 
 jobs:
   lint:

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: '14.x'
+  NODE_VERSION: '16.x'
 
 jobs:
   lint:

--- a/ember-file-upload/README.md
+++ b/ember-file-upload/README.md
@@ -13,7 +13,7 @@ Uploads can be managed through queues and continue in the background, even after
 * Ember.js 3.25 or above
 * ember-auto-import 2.0 or above
 * Ember CLI v2.13 or above
-* Node.js v14 or above
+* Node.js v16 or above
 * Modern browsers. Internet Explorer 11 might work but is not offically supported.
 * Strict Content Security Policy (CSP) except for mirage route handlers, which require `data:` protocol to be included in `image-src` and `media-src` directives.
 

--- a/ember-file-upload/package.json
+++ b/ember-file-upload/package.json
@@ -120,7 +120,7 @@
     }
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -84,7 +84,7 @@
     }
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "ember": {
     "edition": "octane"

--- a/website/package.json
+++ b/website/package.json
@@ -81,7 +81,7 @@
     "webpack": "^5.78.0"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Node 14 support ends on 30 Apr 2023.

Planning to batch this with #917 as the breaking changes for v8.