### PR TITLE
Constrain renovate to pnpm version 7

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,8 @@
       "matchPackagePrefixes": ["@types/ember__"],
       "groupName": "ember types"
     }
-  ]
+  ],
+  "constraints": {
+    "pnpm": "7"
+  }
 }


### PR DESCRIPTION
Should avoid the lockfile version from being updated and enable Renovate PRs to run in CI.