### PR TITLE
Demo upload – flush queue after successful upload

### DIFF
--- a/website/app/components/demo-upload.js
+++ b/website/app/components/demo-upload.js
@@ -42,5 +42,6 @@ export default class DemoUploadComponent extends Component {
     }
 
     file.state = FileState.Uploaded;
+    file.queue.flush();
   }
 }


### PR DESCRIPTION
Due to queue flushing adjustment in https://github.com/adopted-ember-addons/ember-file-upload/pull/925 this needs to be called explicitly here so that the queue is cleared after an upload completes.

Ideally this demo would use Mock Service Worker in future.