### PR TITLE
Document `peerDependency` requirements for v8

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,20 @@ Uploads can be managed through queues and continue in the background, even after
 ember install ember-file-upload
 ```
 
+To ensure your app has all requred `devDependencies` you may also run:
+
+```sh
+# pnpm
+pnpm add --save-dev @ember/test-helpers @glimmer/component @glimmer/tracking ember-modifier tracked-built-ins
+
+# npm
+npm install --save-dev @ember/test-helpers @glimmer/component @glimmer/tracking ember-modifier tracked-built-ins
+
+# Yarn
+yarn add --dev @ember/test-helpers @glimmer/component @glimmer/tracking ember-modifier tracked-built-ins
+```
+
+
 ## Introducing queues
 
 Queues contain the state of file uploads as a user navigates around your application. They are the core of this addon.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,6 +4,33 @@ order: 7
 
 # Upgrade guide
 
+## Upgrading to v8
+
+The following packages are now `peerDependencies` of `ember-file-upload`:
+
+- `@ember/test-helpers`
+- `@glimmer/component`
+- `@glimmer/tracking`
+- `ember-modifier`
+- `tracked-built-ins`
+
+This means your app or addon must provide its own version of these packages via `devDependencies` or `dependencies`.
+
+Most apps will already have these packages installed as they are included in new Ember apps by default.
+
+To ensure an existing app has all requred `devDependencies` you may run:
+
+```sh
+# pnpm
+pnpm add --save-dev @ember/test-helpers @glimmer/component @glimmer/tracking ember-modifier tracked-built-ins
+
+# npm
+npm install --save-dev @ember/test-helpers @glimmer/component @glimmer/tracking ember-modifier tracked-built-ins
+
+# Yarn
+yarn add --dev @ember/test-helpers @glimmer/component @glimmer/tracking ember-modifier tracked-built-ins
+```
+
 ## Upgrading to v7
 
 No changes are required unless an app directly imports modules from this addon.

--- a/ember-file-upload/CHANGELOG.md
+++ b/ember-file-upload/CHANGELOG.md
@@ -1,19 +1,6 @@
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 ## v8.0.0 (2023-05-01)
+
+[Upgrade guide](https://ember-file-upload.pages.dev/docs/upgrade-guide#upgrading-to-v8)
 
 #### :boom: Breaking Change
 * [#922](https://github.com/adopted-ember-addons/ember-file-upload/pull/922) Drop support for node 14 ([@gilest](https://github.com/gilest))


### PR DESCRIPTION
Documentation for https://github.com/adopted-ember-addons/ember-file-upload/pull/917 which I probably should have included before release 😅 

Should help clarify the upgrade path for cases such as #926 as well as new installations