### PR TITLE
Update `test-app` browser targets from latest `ember-cli` blueprint

### DIFF
--- a/test-app/config/targets.js
+++ b/test-app/config/targets.js
@@ -1,14 +1,9 @@
 'use strict';
 
 const browsers = [
-  'last 2 Chrome versions',
-  'last 2 Firefox versions',
-  'Firefox ESR',
-  'last 2 Safari versions',
-  // Last versions of Microsoft Edge are build on top of Chromium. But they are
-  // not shipped yet to a significant number of users. Need to still support
-  // Edge 18 explicitly until chromium-based Edge is shipped to all users.
-  'Edge >= 18',
+  'last 1 Chrome versions',
+  'last 1 Firefox versions',
+  'last 1 Safari versions',
 ];
 
 module.exports = {


### PR DESCRIPTION
Believe this configuration is pretty stale and no longer necessary.

Resolves ember-try test builds failing with `ember-source` `> 5.0.0`.

> not ok 1 Chrome 113.0 - [undefined ms] - Global error: Uncaught TypeError: (0 , _emberBabel.extends) is not a function at http://localhost:7357/assets/vendor.js, line 12297

Error output looks similar to emberjs/ember.js/issues/20281 so I'm linking here in case it helps other trace this issue.