### PR TITLE
Relax peer dependency version for @ember/test-helpers

### DIFF
--- a/ember-file-upload/package.json
+++ b/ember-file-upload/package.json
@@ -110,7 +110,7 @@
     "webpack": "^5.74.0"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^2.9.3",
+    "@ember/test-helpers": "^2.9.3 || ^3.0.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "ember-cli-mirage": "*",


### PR DESCRIPTION
Allow `@ember/test-helpers` v3 to be used with this addon. v3 was released a few weeks ago and doesn’t seem to have any changes impacting this addon ([release notes](https://github.com/emberjs/ember-test-helpers/releases/tag/v3.0.0)). I’ve been using it with `ember-file-upload` for a while now and haven’t had any issues, so recommend relaxing the peer requirements so npm won’t protest when trying to install the latest test-helpers version.

For now I’ve set the version range to `^2.9.3 || ^3.0.3` (since 3.0.3 seems to be the [earliest stable version](https://github.com/emberjs/ember-test-helpers/releases#hd-22950539)) but could relax even more (`>= 2.9.3`?) if that makes sense.