### PR TITLE
Cast queue name to string when rendering it in test-app

### DIFF
--- a/test-app/app/helpers/equals.js
+++ b/test-app/app/helpers/equals.js
@@ -1,5 +1,0 @@
-import { helper } from '@ember/component/helper';
-
-export default helper(function ([a, b]) {
-  return a === b;
-});

--- a/test-app/app/helpers/to-string.ts
+++ b/test-app/app/helpers/to-string.ts
@@ -1,0 +1,13 @@
+import { helper } from '@ember/component/helper';
+
+export interface ToStringSignature {
+  Args: {
+    Positional: Array<unknown>;
+    Named: Record<string, never>;
+  };
+  Return: string;
+}
+
+export default helper<ToStringSignature>(function ([input]) {
+  return input?.toString() ?? '';
+});

--- a/test-app/tests/helpers/file-queue-helper-test.ts
+++ b/test-app/tests/helpers/file-queue-helper-test.ts
@@ -75,8 +75,7 @@ module('Integration | Helper | file-queue', function (hooks) {
   test('falls back to default name', async function (this: LocalContext, assert) {
     await render<LocalContext>(hbs`
       {{#let (file-queue) as |queue|}}
-        {{! @glint-ignore: https://github.com/typed-ember/glint/discussions/611 }}
-        <output>{{queue.name}}</output>
+        <output>{{to-string queue.name}}</output>
       {{/let}}
     `);
 
@@ -86,8 +85,7 @@ module('Integration | Helper | file-queue', function (hooks) {
   test('can be parametrized by name', async function (this: LocalContext, assert) {
     await render<LocalContext>(hbs`
       {{#let (file-queue name="line-up") as |queue|}}
-        {{! @glint-ignore: https://github.com/typed-ember/glint/discussions/611 }}
-        <output>{{queue.name}}</output>
+        <output>{{to-string queue.name}}</output>
       {{/let}}
     `);
 

--- a/test-app/tests/integration/components/file-dropzone-test.ts
+++ b/test-app/tests/integration/components/file-dropzone-test.ts
@@ -102,8 +102,7 @@ module('Integration | Component | FileDropzone', function (hooks) {
           <FileDropzone @queue={{helperQueue}} as |dropzone queue|>
             <div class="supported">{{dropzone.supported}}</div>
             <div class="active">{{dropzone.active}}</div>
-            {{! @glint-ignore: https://github.com/typed-ember/glint/discussions/611 }}
-            <div class="queue-name">{{queue.name}}</div>
+            <div class="queue-name">{{to-string queue.name}}</div>
           </FileDropzone>
         {{/let}}
       `);

--- a/test-app/types/global.d.ts
+++ b/test-app/types/global.d.ts
@@ -1,6 +1,7 @@
 import '@glint/environment-ember-loose';
 import type EmberFileUploadRegistry from 'ember-file-upload/template-registry';
 import DemoUpload from 'test-app/components/demo-upload';
+import toString from 'test-app/helpers/to-string';
 
 // Types for compiled templates
 declare module 'test-app/templates/*' {
@@ -20,5 +21,6 @@ declare module '@glint/environment-ember-loose/registry' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export default interface Registry extends EmberFileUploadRegistry {
     DemoUpload: typeof DemoUpload;
+    'to-string': typeof toString;
   }
 }


### PR DESCRIPTION
Since this type can be a symbol, Glint does not consider it to be a good value to render.