### PR TITLE
Document Glint type support

### DIFF
--- a/docs/api/class/queue.md
+++ b/docs/api/class/queue.md
@@ -8,6 +8,8 @@ The Queue is a collection of files that are being manipulated by the user.
 
 Queues are designed to persist the state of uploads when a user navigates around your application.
 
+## Import parth
+
 ```js
 import { Queue } from 'ember-file-upload';
 ```
@@ -30,11 +32,11 @@ Upload failures can happen due to a timeout or a server response. If you choose 
 
 ## Fields
 
-| Field       | Description                                                                                                   | Type           |
-| ----------- | ------------------------------------------------------------------------------------------------------------- | -------------- |
-| `fileQueue` | The FileQueue service.                                                                                        | `FileQueue`    |
-| `name`      | The unique identifier of the queue.                                                                           | `string`       |
-| `files`     | The list of files in the queue. This automatically gets flushed when all the files in the queue have settled. | `UploadFile[]` |
+| Field       | Description                                                                                                   | Type               |
+| ----------- | ------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `fileQueue` | The FileQueue service.                                                                                        | `FileQueue`        |
+| `name`      | The unique identifier of the queue.                                                                           | `string \| symbol` |
+| `files`     | The list of files in the queue. This automatically gets flushed when all the files in the queue have settled. | `UploadFile[]`     |
 
 ## Methods
 

--- a/docs/api/class/upload-file.md
+++ b/docs/api/class/upload-file.md
@@ -6,6 +6,8 @@ category: class
 
 The `UploadFile` class provides a uniform interface for interacting with data that can be uploaded or read.
 
+## Import parth
+
 ```js
 import { UploadFile } from 'ember-file-upload';
 ```

--- a/docs/api/component/file-dropzone.md
+++ b/docs/api/component/file-dropzone.md
@@ -26,6 +26,12 @@ drag and drop.
 </FileDropzone>
 ```
 
+## Import parth
+
+```js
+import FileDropzone from 'ember-file-upload/components/file-dropzone';
+```
+
 # Component API
 
 ## Arguments

--- a/docs/api/helper/file-queue.md
+++ b/docs/api/helper/file-queue.md
@@ -22,6 +22,12 @@ If a name is not provided, the default queue will be used.
 {{/let}}
 ```
 
+## Import parth
+
+```js
+import fileQueue from 'ember-file-upload/helpers/file-queue';
+```
+
 # Helper API
 
 ## Arguments

--- a/docs/api/service/file-queue-service.md
+++ b/docs/api/service/file-queue-service.md
@@ -8,8 +8,10 @@ The `FileQueueService` is a global file queue that manages all files being uploa
 
 This service can be used to query the current upload state when a user leaves the app, asking them whether they want to cancel the remaining uploads.
 
+## Import parth
+
 ```js
-import { FileQueueService } from 'ember-file-upload';
+import FileQueueService from 'ember-file-upload/services/file-queue';
 ```
 
 # Service API

--- a/docs/glint.md
+++ b/docs/glint.md
@@ -1,0 +1,26 @@
+---
+order: 5
+---
+
+# Glint types
+
+All components and helpers have proper [Glint](https://github.com/typed-ember/glint) types, which allow you when using TypeScript to get strict type checking in your templates.
+
+Unless you are using [strict mode](http://emberjs.github.io/rfcs/0496-handlebars-strict-mode.html) templates (via [first class component templates](http://emberjs.github.io/rfcs/0779-first-class-component-templates.html)),
+you need to import the addon's Glint template registry and `extend` your app's registry declaration as described in the [Using Addons](https://typed-ember.gitbook.io/glint/using-glint/ember/using-addons#using-glint-enabled-addons) documentation:
+
+```ts
+import '@glint/environment-ember-loose';
+
+import type EmberFileUploadRegistry from 'ember-file-upload/template-registry';
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry extends EmberFileUploadRegistry, /* other addon registries */ {
+    // local entries
+  }
+}
+```
+
+Should you want to manage the registry by yourself, then omit this import, and instead add the entries in your app by explicitly importing the types of the components and helpers from this addon.
+
+> Note that Glint itself is still under active development, and as such breaking changes might occur. Therefore, Glint support by this addon is also considered experimental, and not covered by our SemVer contract!

--- a/test-app/tests/integration/services/file-queue-test.ts
+++ b/test-app/tests/integration/services/file-queue-test.ts
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, TestContext } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { UploadFile, FileSource, FileQueueService } from 'ember-file-upload';
+import { UploadFile, FileSource } from 'ember-file-upload';
+import type FileQueueService from 'ember-file-upload/services/file-queue';
 
 interface LocalTestContext extends TestContext {
   subject: FileQueueService;


### PR DESCRIPTION
Adds import paths to API docs and a new [Glint types page](https://docs-glint.ember-file-upload.pages.dev/docs/glint) to the docsite.