### PR TITLE
Add CI matrix to type-check TypeScript versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,18 @@ jobs:
         run: pnpm --filter test-app test:ember --launch chrome
 
   typecheck:
-    name: Typecheck
+    name: 'Typecheck ${{ matrix.typescript-scenario }}'
     runs-on: ubuntu-latest
     needs: lint
+    continue-on-error: true
+    strategy:
+      fail-fast: true
+      matrix:
+        typescript-scenario:
+          - typescript@5.0
+          - typescript@5.1
+          - typescript@5.2
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -79,8 +88,15 @@ jobs:
       - name: 'Install dependencies'
         run: pnpm install --frozen-lockfile
 
+      - name: 'Change TS to ${{ matrix.typescript-scenario }}'
+        run: 'pnpm add --save-dev ${{ matrix.typescript-scenario}}'
+        working-directory: ./test-app
+
       - name: Lint
-        run: pnpm --filter test-app lint:types
+        run: |
+          pnpm --filter "test-app*" exec tsc -v;
+          pnpm --filter "test-app*" exec glint --version;
+          pnpm --filter "test-app*" lint:types;
 
   floating-dependencies:
     name: Tests - Floating Dependencies

--- a/ember-file-upload/README.md
+++ b/ember-file-upload/README.md
@@ -11,6 +11,7 @@ Uploads can be managed through queues and continue in the background, even after
 ## Compatibility
 
 * Ember.js 3.25 or above
+* TypeScript 5.0 or above
 * ember-auto-import 2.0 or above
 * Ember CLI v2.13 or above
 * Node.js v16 or above


### PR DESCRIPTION
Also adds "TypeScript 5 and above" to the Compatibility section of the readme. This is an indication based off what passed in CI.

We haven't yet adopted an official support policy for TypeScript.