### PR TITLE
Incorrect file loaded reporting

### DIFF
--- a/ember-file-upload/src/system/upload.ts
+++ b/ember-file-upload/src/system/upload.ts
@@ -100,7 +100,7 @@ export function upload(
     if (!evt) return;
     if (!evt.lengthComputable || evt.total === 0) return;
 
-    file.loaded = evt.loaded;
+    file.loaded = Math.max(evt.loaded, file.loaded);
     file.progress = (file.loaded / file.size) * 100;
   };
 

--- a/ember-file-upload/src/system/upload.ts
+++ b/ember-file-upload/src/system/upload.ts
@@ -100,7 +100,15 @@ export function upload(
     if (!evt) return;
     if (!evt.lengthComputable || evt.total === 0) return;
 
-    file.loaded = Math.max(evt.loaded, file.loaded);
+    // When the progress is completed there is possible that we get the `Content-Length` response header of the upload endpoint as loaded / total.
+    // There is possible that `Content-Length` is lower or higher than the already loaded bytes.
+    // if there is lower, we want to keep the higher loaded value, otherwise the progress percentage will be decreased
+    // When the evt.loaded is higher than the start file.size, we use the file.size, otherwise it can occur that progress for the file is higher than 100%
+    let loaded = evt.loaded;
+    if (loaded > file.size) {
+      loaded = file.size;
+    }
+    file.loaded = Math.max(loaded, file.loaded);
     file.progress = (file.loaded / file.size) * 100;
   };
 


### PR DESCRIPTION
When the upload is completed, `request.onprogress` will be fired at the same time like `request.onloadend`.
As the upload is completed with `request.onprogress` the server returns the `Content-Length` and the browser takes this size... In my case the returned `Content-Length` is lower, because i don't return the image and so the progress bar is going back.

My debug console.logs:
![grafik](https://github.com/adopted-ember-addons/ember-file-upload/assets/19845290/beed432f-9dfd-4639-86e1-66b5c7e56944)

To fix this behavier we should replace the `file.loaded` set in `request.onprogress` to:
`file.loaded = Math.max(evt.loaded, file.loaded);` instead of `file.loaded = evt.loaded;`

Comment copied from: https://github.com/adopted-ember-addons/ember-file-upload/pull/1002#issuecomment-1775101785