### PR TITLE
Support `verbatimModuleSyntax` in test app

### DIFF
--- a/test-app/tests/helpers/file-queue-helper-test.ts
+++ b/test-app/tests/helpers/file-queue-helper-test.ts
@@ -9,7 +9,7 @@ import { selectFiles } from 'ember-file-upload/test-support';
 import { uploadHandler } from 'ember-file-upload';
 import { later } from '@ember/runloop';
 
-import { MirageTestContext, setupMirage } from 'ember-cli-mirage/test-support';
+import { type MirageTestContext, setupMirage } from 'ember-cli-mirage/test-support';
 
 interface LocalContext extends MirageTestContext {
   filter: (file: File, files: File[], index: number) => boolean;

--- a/test-app/tests/integration/components/file-dropzone-test.ts
+++ b/test-app/tests/integration/components/file-dropzone-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, triggerEvent, TestContext } from '@ember/test-helpers';
+import { render, triggerEvent, type TestContext } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import {
   dragAndDrop,

--- a/test-app/tests/integration/mirage-handler-test.ts
+++ b/test-app/tests/integration/mirage-handler-test.ts
@@ -11,7 +11,7 @@ import {
   ogg,
   png,
 } from 'test-app/tests/utils/file-data';
-import { MirageTestContext, setupMirage } from 'ember-cli-mirage/test-support';
+import { type MirageTestContext, setupMirage } from 'ember-cli-mirage/test-support';
 import type { UploadFile } from 'ember-file-upload';
 
 interface LocalTestContext extends MirageTestContext {

--- a/test-app/tests/integration/progress-test.ts
+++ b/test-app/tests/integration/progress-test.ts
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { selectFiles } from 'ember-file-upload/test-support';
-import { MirageTestContext, setupMirage } from 'ember-cli-mirage/test-support';
+import { type MirageTestContext, setupMirage } from 'ember-cli-mirage/test-support';
 import { TrackedArray } from 'tracked-built-ins';
 import { type Asset } from 'test-app/components/demo-upload';
 import type Owner from '@ember/owner';

--- a/test-app/tests/integration/queue-listeners-test.ts
+++ b/test-app/tests/integration/queue-listeners-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { TestContext, render, settled } from '@ember/test-helpers';
+import { type TestContext, render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { selectFiles } from 'ember-file-upload/test-support';
 import { tracked } from '@glimmer/tracking';

--- a/test-app/tests/integration/services/file-queue-test.ts
+++ b/test-app/tests/integration/services/file-queue-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, TestContext } from '@ember/test-helpers';
+import { render, settled, type TestContext } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { UploadFile, FileSource } from 'ember-file-upload';
 import type FileQueueService from 'ember-file-upload/services/file-queue';

--- a/test-app/tests/integration/upload-test.ts
+++ b/test-app/tests/integration/upload-test.ts
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { selectFiles } from 'ember-file-upload/test-support';
-import { MirageTestContext, setupMirage } from 'ember-cli-mirage/test-support';
+import { type MirageTestContext, setupMirage } from 'ember-cli-mirage/test-support';
 import { TrackedArray } from 'tracked-built-ins';
 import { type Asset } from 'test-app/components/demo-upload';
 import getImageBlob from 'test-app/tests/helpers/get-image-blob';

--- a/test-app/tests/unit/services/file-queue-test.ts
+++ b/test-app/tests/unit/services/file-queue-test.ts
@@ -6,7 +6,7 @@ import {
   FileState,
   UploadFile,
 } from 'ember-file-upload';
-import { TestContext } from '@ember/test-helpers';
+import { type TestContext } from '@ember/test-helpers';
 import { png } from 'test-app/tests/utils/file-data';
 
 module('Unit | Service | file-queue', function (hooks) {

--- a/test-app/tests/unit/upload-file-test.ts
+++ b/test-app/tests/unit/upload-file-test.ts
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import { uploadHandler } from 'ember-file-upload';
 import { UploadFile, FileSource } from 'ember-file-upload';
 
-import { MirageTestContext, setupMirage } from 'ember-cli-mirage/test-support';
+import { type MirageTestContext, setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Unit | UploadFile', function (hooks) {
   setupTest(hooks);

--- a/test-app/tsconfig.json
+++ b/test-app/tsconfig.json
@@ -13,7 +13,6 @@
         "types/*"
       ]
     },
-    "moduleResolution": "node16",
     "skipLibCheck": true
   },
   "glint": {


### PR DESCRIPTION
Required as `@tsconfig/ember` has added `"verbatimModuleSyntax": true,`

https://github.com/tsconfig/bases/commit/aacda4360f03651bd3b70de8d0840c8907ce897b

Ref: failing build #1008