### PR TITLE
Upload progress incorrect in Google Chrome

### DIFF
--- a/ember-file-upload/src/upload-file.ts
+++ b/ember-file-upload/src/upload-file.ts
@@ -87,6 +87,11 @@ export class UploadFile {
    * range of 0 to 100.
    */
   @tracked progress = 0;
+  
+  /**
+   * When upload has finished this property will be set to true
+   */
+  @tracked isUploadComplete = false;
 
   /**
    * The current state that the file is in.

--- a/ember-file-upload/src/upload-file.ts
+++ b/ember-file-upload/src/upload-file.ts
@@ -87,7 +87,7 @@ export class UploadFile {
    * range of 0 to 100.
    */
   @tracked progress = 0;
-  
+
   /**
    * When upload has finished this property will be set to true
    */


### PR DESCRIPTION
Sometimes the browser doesn't has the correct file size `onloadstart`. like described here: https://github.com/adopted-ember-addons/ember-file-upload/pull/1002#issuecomment-1801198715

During debugging i have found out, that this bug is present in Chrome. In Chrome there is often a total wrong `total` size (see [comment](https://github.com/adopted-ember-addons/ember-file-upload/pull/1002#issuecomment-1801264134)) and in Firefox there is sometime a little difference between the total size `onloadstart` and `onprogress`.

We should set `file.size` like in earlier versions also in `onprogress` event and check in `progress` event, if the upload is already complete.

#1013


Progress log on Chrome with this fix (3 files in queue):
```
0
0
1
1
3
3
5
5
6
6
8
8
10
10
11
11
13
13
15
15
16
16
18
18
20
20
21
21
23
23
24
24
24
24
24
24
24
24 // first file uploaded
26
26
27
27
29
29
31
31
33
33
34
34
36
36
38
38
39
39
41
41
43
43
44
44
46
46
48
48
49
49
51
51
53
53
55
55
56
56
58
58
60
60
61
61
63
63
65
65
66
66
68
68
70
70
71
71
73
73
75
75
76
76
78
78
80
80
82
82
83
83
85
85
87
87
88
88
88
88
88
88
88 // 2nd file uploaded
88
89
89
91
91
93
93
95
95
96
96
98
98
100
100
100
100 // all files uploaded
```

Progress log in Firefox after fix (3 files in queue):
```
3
6
9
12
15
19
22
24
24 // first file uploaded
27
31
34
37
40
43
47
50
53
56
59
62
66
69
72
75
78
82
85
86
86 // 2nd file uploaded
89
92
95
98
100 // all files uploaded
```

