### PR TITLE
Website demo – support HTTP uploads

### DIFF
--- a/website/app/components/demo-upload.gjs
+++ b/website/app/components/demo-upload.gjs
@@ -8,6 +8,12 @@ import FileDropzone from 'ember-file-upload/components/file-dropzone';
 import fileQueue from 'ember-file-upload/helpers/file-queue';
 import { onloadstart, onprogress, onloadend } from 'ember-file-upload/internal';
 import { on } from '@ember/modifier';
+import { htmlSafe } from '@ember/template';
+
+const UPLOAD_TYPES = {
+  simulated: 'Simulated 🧑‍🔬',
+  http: 'HTTP 📡',
+};
 
 // Values in kilobits per second (kbps)
 const UPLOAD_RATES = {
@@ -19,6 +25,13 @@ const UPLOAD_RATES = {
   '4G/LTE - 50 Mbps': 50_000,
   'Fast Fibre - 100 Mbps': 100_000,
 };
+const DEFAULT_RATE = UPLOAD_RATES['Fast 3G - 0.675 Mbps'];
+const DEFAULT_URL = 'https://api.bytescale.com/v1/files/basic';
+const DEFAULT_HEADERS = {
+  Authorization: 'Basic YXBpa2V5OmZyZWU',
+  'Content-Type': 'application/x-www-form-urlencoded',
+};
+const DEFAULT_METHOD = 'POST';
 
 const STEP_INTERVAL = 100; // Progress events every 100ms
 const STEPS_PER_SECOND = 1_000 / STEP_INTERVAL;
@@ -33,7 +46,14 @@ export default class DemoUploadComponent extends Component {
   @service fileQueue;
 
   @tracked files = [];
-  @tracked uploadRate = UPLOAD_RATES['Fast 3G - 0.675 Mbps'];
+
+  @tracked uploadOptions = {
+    type: UPLOAD_TYPES.simulated,
+    rate: DEFAULT_RATE,
+    url: DEFAULT_URL,
+    method: DEFAULT_METHOD,
+    headers: DEFAULT_HEADERS,
+  };
 
   get queue() {
     return this.fileQueue.find('demo');
@@ -42,24 +62,37 @@ export default class DemoUploadComponent extends Component {
   get bytesPerStep() {
     const kilobytesPerSecond =
       // Convert to kilobytes
-      (this.uploadRate / BITS_PER_BYTE) *
+      (this.uploadOptions.rate / BITS_PER_BYTE) *
       // and then to bytes
       BYTES_PER_KILOBYTE;
     return kilobytesPerSecond / STEPS_PER_SECOND;
   }
 
   @action
-  setUploadRate(event) {
-    this.uploadRate = parseInt(event.target.value, 10);
+  setUploadOptions(event) {
+    const formData = new FormData(event.currentTarget);
+    const entries = Object.fromEntries(formData.entries());
+    this.uploadOptions = {
+      ...entries,
+      rate: parseInt(entries.rate, 10),
+      headers: JSON.parse(entries.headers),
+    };
   }
 
   @action
   addToQueue(file) {
-    file.queue = this.queue;
-    file.state = FileState.Queued;
     this.files = [file, ...this.files];
 
-    this.simulateUpload.perform(file);
+    switch (this.uploadOptions.type) {
+      case UPLOAD_TYPES.simulated:
+        file.queue = this.queue;
+        file.state = FileState.Queued;
+        this.simulateUpload.perform(file);
+        break;
+      case UPLOAD_TYPES.http:
+        this.httpUpload.perform(file);
+        break;
+    }
   }
 
   @task({ enqueue: true })
@@ -101,17 +134,65 @@ export default class DemoUploadComponent extends Component {
     file.queue.flush();
   }
 
+  @task({ enqueue: true })
+  *httpUpload(file) {
+    yield file.upload(this.uploadOptions.url, {
+      method: this.uploadOptions.method,
+      headers: this.uploadOptions.headers,
+    });
+  }
+
+  toggleVisibility = (type) => {
+    return this.uploadOptions.type === type
+      ? htmlSafe('')
+      : htmlSafe('display: none');
+  };
+
   <template>
-    <form aria-label='Simulate upload speed'>
-      <label>
-        Simulate upload speed:
-        <select name='uploadRate' {{on 'change' this.setUploadRate}}>
+    {{log this.uploadOptions}}
+    <form aria-label='Upload options' {{on 'change' this.setUploadOptions}}>
+      <fieldset>
+        <legend>Upload type:</legend>
+        <label>
+          {{#each-in UPLOAD_TYPES as |_key type|}}
+            <div>
+              <input
+                type='radio'
+                name='type'
+                id={{type}}
+                value={{type}}
+                checked={{eq this.uploadOptions.type type}}
+              />
+              <label for={{type}}>{{type}}</label>
+            </div>
+          {{/each-in}}
+        </label>
+      </fieldset>
+
+      <label style={{this.toggleVisibility UPLOAD_TYPES.simulated}}>
+        Simulated speed:
+        <select name='rate'>
           {{#each-in UPLOAD_RATES as |name rate|}}
-            <option value={{rate}} selected={{eq this.uploadRate rate}}>
+            <option value={{rate}} selected={{eq this.uploadOptions.rate rate}}>
               {{name}}
             </option>
           {{/each-in}}
         </select>
+      </label>
+
+      <label style={{this.toggleVisibility UPLOAD_TYPES.http}}>
+        URL:
+        <input type='text' name='url' value={{DEFAULT_URL}} />
+      </label>
+
+      <label style={{this.toggleVisibility UPLOAD_TYPES.http}}>
+        Method:
+        <input type='text' name='method' value={{DEFAULT_METHOD}} />
+      </label>
+
+      <label style={{this.toggleVisibility UPLOAD_TYPES.http}}>
+        Headers:
+        <textarea name='headers' rows='5' spellcheck='false'>{{JSON.stringify DEFAULT_HEADERS null 2}}</textarea>
       </label>
     </form>
 

--- a/website/app/components/options-form.gjs
+++ b/website/app/components/options-form.gjs
@@ -1,0 +1,120 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+import { htmlSafe } from '@ember/template';
+
+export const UPLOAD_TYPES = {
+  simulated: 'Simulated 🧑‍🔬',
+  http: 'HTTP 📡',
+};
+
+// Simulated
+// Values in kilobits per second (kbps)
+const RATES = {
+  'Disconnected - 0 Mbps': 0,
+  'Very slow - 0.1 Mbps': 100,
+  'Slow 3G - 0.4 Mbps': 400,
+  'Fast 3G - 0.675 Mbps': 675,
+  'ADSL - 1.5 Mbps': 1_500,
+  '4G/LTE - 50 Mbps': 50_000,
+  'Fast Fibre - 100 Mbps': 100_000,
+};
+const DEFAULT_RATE = RATES['Fast 3G - 0.675 Mbps'];
+
+// HTTP
+const DEFAULT_URL = 'https://api.bytescale.com/v1/files/basic';
+const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'HEAD'];
+const DEFAULT_METHOD = 'POST';
+const DEFAULT_HEADERS = {
+  Authorization: 'Basic YXBpa2V5OmZyZWU',
+  'Content-Type': 'application/x-www-form-urlencoded',
+};
+
+export const DEFAULT_OPTIONS = {
+  type: UPLOAD_TYPES.simulated,
+  // Simulated
+  rate: DEFAULT_RATE,
+  // HTTP
+  url: DEFAULT_URL,
+  method: DEFAULT_METHOD,
+  headers: DEFAULT_HEADERS,
+};
+
+const eq = (a, b) => a === b;
+
+export default class OptionsFormComponent extends Component {
+  @action
+  setOptions(event) {
+    const formData = new FormData(event.currentTarget);
+    const entries = Object.fromEntries(formData.entries());
+    const uploadOptions = {
+      ...entries,
+      rate: parseInt(entries.rate, 10),
+      headers: JSON.parse(entries.headers),
+    };
+    this.args.onUpdate(uploadOptions);
+  }
+
+  // Keep forms in DOM to prevent data loss
+  toggleVisibility = (type) => {
+    return this.args.uploadOptions.type === type
+      ? htmlSafe('')
+      : htmlSafe('display: none');
+  };
+
+  <template>
+    <form aria-label='Upload options' {{on 'change' this.setOptions}}>
+      <fieldset>
+        <legend>Upload type:</legend>
+        {{#each (Object.values UPLOAD_TYPES) as |type|}}
+          <div>
+            <input
+              type='radio'
+              name='type'
+              id={{type}}
+              value={{type}}
+              checked={{eq @uploadOptions.type type}}
+            />
+            <label for={{type}}>{{type}}</label>
+          </div>
+        {{/each}}
+      </fieldset>
+
+      <label style={{this.toggleVisibility UPLOAD_TYPES.simulated}}>
+        Simulated speed:
+        <select name='rate'>
+          {{#each-in RATES as |name rate|}}
+            <option value={{rate}} selected={{eq @uploadOptions.rate rate}}>
+              {{name}}
+            </option>
+          {{/each-in}}
+        </select>
+      </label>
+
+      <label style={{this.toggleVisibility UPLOAD_TYPES.http}}>
+        URL:
+        <input type='text' name='url' value={{DEFAULT_URL}} />
+      </label>
+
+      <label style={{this.toggleVisibility UPLOAD_TYPES.http}}>
+        Method:
+        <select name='method'>
+          {{#each METHODS as |method|}}
+            <option value={{method}} selected={{eq @uploadOptions.method method}}>
+              {{method}}
+            </option>
+          {{/each}}
+        </select>
+      </label>
+
+      <label style={{this.toggleVisibility UPLOAD_TYPES.http}}>
+        Headers:
+        <textarea name='headers' rows='5' spellcheck='false'>{{JSON.stringify
+            DEFAULT_HEADERS
+            null
+            2
+          }}</textarea>
+      </label>
+    </form>
+  </template>
+}

--- a/website/app/components/options-form.gjs
+++ b/website/app/components/options-form.gjs
@@ -22,12 +22,11 @@ const RATES = {
 const DEFAULT_RATE = RATES['Fast 3G - 0.675 Mbps'];
 
 // HTTP
-const DEFAULT_URL = 'https://api.bytescale.com/v1/files/basic';
+const DEFAULT_URL = 'https://m6v5v.wiremockapi.cloud/files';
 const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'HEAD'];
 const DEFAULT_METHOD = 'POST';
 const DEFAULT_HEADERS = {
-  Authorization: 'Basic YXBpa2V5OmZyZWU',
-  'Content-Type': 'application/x-www-form-urlencoded',
+  Authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l',
 };
 
 export const DEFAULT_OPTIONS = {


### PR DESCRIPTION
This will be useful for debugging issues and testing new features.

Users being able to interactively explore this addon should help them understand and visualise the less-documented functionality like queue flushing.

### UI

<img width="766" alt="image" src="https://github.com/adopted-ember-addons/ember-file-upload/assets/36919/19df02d1-e4e7-4794-86bd-3ed38591ed5a">

### Example HTTP upload

<img width="1072" alt="image" src="https://github.com/adopted-ember-addons/ember-file-upload/assets/36919/226615b7-74d2-4043-8793-ea01d0941b9b">
