### PR TITLE
Prepare running twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "scripts": {
     "ember-try-one": "pnpm -F test-app ember-try-one",
-    "prepare": "pnpm -F ember-file-upload prepare",
     "release": "pnpm prepare && pnpm -F ember-file-upload release",
     "start": "npm-run-all --parallel start:*",
     "start:addon": "pnpm -F ember-file-upload start",


### PR DESCRIPTION
Since #1031 running local commands like `pnpm install` causes the addon build to run twice.

This is because we added a workspace-level prepare script while leaving the package-level prepare script in place.

This PR removes the workspace-level prepare script to restore a single build being run.

Example:

```
➜  ember-file-upload git:(master) p i
ember-file-upload prepare$ pnpm build
[7 lines collapsed]
│ [js] > ember-file-upload@8.4.0 build:js
│ [js] > rollup --config
│ [js]
│ [js]
│ [js]  → dist...
│ [js] (!) Generated an empty chunk
│ [js] "template-registry"
│ [js] created dist in 715ms
│ [js] npm run build:js exited with code 0
│ [types] npm run build:types exited with code 0
└─ Done in 4s
. prepare$ pnpm -F ember-file-upload prepare
[9 lines collapsed]
│ [js] > ember-file-upload@8.4.0 build:js
│ [js] > rollup --config
│ [js]
│ [js]
│ [js]  → dist...
│ [js] (!) Generated an empty chunk
│ [js] "template-registry"
│ [js] created dist in 716ms
│ [js] npm run build:js exited with code 0
│ [types] npm run build:types exited with code 0
└─ Done in 4s
Done in 7.2s
```

With this change it will run only once again:
```
➜  ember-file-upload git:(master) ✗ p i
. prepare$ pnpm -F ember-file-upload build
[7 lines collapsed]
│ [types] > ember-file-upload@8.4.0 build:types
│ [types] > glint --declaration
│ [types]
│ [js]
│ [js]  → dist...
│ [js] (!) Generated an empty chunk
│ [js] "template-registry"
│ [js] created dist in 596ms
│ [js] npm run build:js exited with code 0
│ [types] npm run build:types exited with code 0
└─ Done in 2.7s
Done in 3.6s
```
