### PR TITLE
Improve release config

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "release-it": {
     "plugins": {
       "@release-it-plugins/workspaces": {
-        "publish": false
+        "workspaces": ["ember-file-upload"]
       },
       "@release-it-plugins/lerna-changelog": {
         "infile": "CHANGELOG.md",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,7 +241,7 @@ importers:
         specifier: ^8.1.2
         version: 8.1.2
       ember-file-upload:
-        specifier: 8.4.0
+        specifier: workspace:*
         version: file:ember-file-upload(@ember/test-helpers@3.2.1)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-cli-mirage@3.0.2)(ember-modifier@4.1.0)(miragejs@0.1.48)(tracked-built-ins@3.3.0)(webpack@5.89.0)
       ember-load-initializers:
         specifier: ^2.1.2
@@ -412,7 +412,7 @@ importers:
         specifier: ^8.1.2
         version: 8.1.2
       ember-file-upload:
-        specifier: 8.4.0
+        specifier: workspace:*
         version: file:ember-file-upload(@ember/test-helpers@3.2.1)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-cli-mirage@3.0.2)(ember-modifier@4.1.0)(miragejs@0.1.48)(tracked-built-ins@3.3.0)(webpack@5.89.0)
       ember-intl:
         specifier: ^6.0.0

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-app",
-  "version": "8.4.1",
+  "version": "0.0.0",
   "private": true,
   "description": "Small description for test-app goes here",
   "repository": "",
@@ -57,7 +57,7 @@
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^3.0.0",
     "ember-fetch": "^8.1.2",
-    "ember-file-upload": "8.4.1",
+    "ember-file-upload": "workspace:*",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",
     "ember-page-title": "^8.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "8.4.1",
+  "version": "0.0.0",
   "private": true,
   "description": "Small description for website goes here",
   "repository": "",
@@ -52,7 +52,7 @@
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^3.0.0",
     "ember-fetch": "^8.1.2",
-    "ember-file-upload": "8.4.1",
+    "ember-file-upload": "workspace:*",
     "ember-intl": "^6.0.0",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",


### PR DESCRIPTION
Some config adjustments since #1031 

The private packages version numbers and dependency on `ember-file-upload` are being bumped. This causes the CI to fail since a new lockfile is not generated. We want to keep the workspace dependency since we're using `dependenciesMeta` to inject this package also.