### PR TITLE
Drop support for Ember 3.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,6 @@ jobs:
       matrix:
         ember-try-scenario:
           [
-            ember-3.25,
             ember-lts-3.28,
             ember-release,
             ember-beta,

--- a/ember-file-upload/README.md
+++ b/ember-file-upload/README.md
@@ -10,15 +10,11 @@ Uploads can be managed through queues and continue in the background, even after
 
 ## Compatibility
 
-* Ember.js 3.25 or above
+* Ember.js 3.28 or above
 * TypeScript 5.0 or above
 * ember-auto-import 2.0 or above
-* Ember CLI v2.13 or above
-* Node.js v16 or above
 * Modern browsers. Internet Explorer 11 might work but is not offically supported.
 * Strict Content Security Policy (CSP) except for mirage route handlers, which require `data:` protocol to be included in `image-src` and `media-src` directives.
-
-For Ember.js < 3.25 use 4.x which is documented by [Legacy docs](https://adopted-ember-addons.github.io/ember-file-upload/docs/).
 
 ## Upgrading
 

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -8,17 +8,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-3.25',
-        npm: {
-          devDependencies: {
-            'ember-cli': '~4.12.2',
-            'ember-source': '~3.25.4',
-            '@ember/test-helpers': '^2.9.4',
-            'ember-qunit': '~6.0.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {

--- a/test-app/tests/helpers/file-queue-helper-test.ts
+++ b/test-app/tests/helpers/file-queue-helper-test.ts
@@ -203,16 +203,6 @@ module('Integration | Helper | file-queue', function (hooks) {
   test('will be notified when an upload fails', async function (this: LocalContext, assert) {
     assert.expect(5);
 
-    // Required for Ember 3.25 run only
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    if (window.Ember) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      window.Ember.onerror = function () {};
-    }
-
     this.server.post(
       '/upload-file',
       uploadHandler(() => new MirageResponse(500)),


### PR DESCRIPTION
Raises minimum supported version to 3.28

Purpose is to allow us to use "strict" mode in the test app (#1048 #1049)

Feel this is reasonable as we still support the final release in 3.x series

Thinking I will merge but not bother releasing until we have other changes to release also

Would be good if there were other breaking changes to batch, but I'm not aware of any