### PR TITLE
feat: allow dropping a folder into the dropzone

### DIFF
--- a/ember-file-upload/src/components/file-dropzone.ts
+++ b/ember-file-upload/src/components/file-dropzone.ts
@@ -65,6 +65,10 @@ export default class FileDropzoneComponent extends Component<FileDropzoneSignatu
     return this.args.multiple ?? true;
   }
 
+  get allowFolderDrop() {
+    return this.args.allowFolderDrop ?? false;
+  }
+
   get files(): File[] {
     const files = this.dataTransferWrapper?.files ?? [];
     if (this.multiple) return files;
@@ -134,7 +138,7 @@ export default class FileDropzoneComponent extends Component<FileDropzoneSignatu
   }
 
   @action
-  didDrop(event: FileUploadDragEvent) {
+  async didDrop(event: FileUploadDragEvent) {
     if (this.dataTransferWrapper) {
       this.dataTransferWrapper.dataTransfer = event.dataTransfer;
     }
@@ -219,9 +223,15 @@ export default class FileDropzoneComponent extends Component<FileDropzoneSignatu
     // }
 
     if (this.dataTransferWrapper) {
-      const addedFiles = this.addFiles(this.files);
-      this.args.onDrop?.(addedFiles, this.dataTransferWrapper);
+      let files;
+      if (this.allowFolderDrop) {
+        files = await this.dataTransferWrapper.getFilesAndDirectories();
+      } else {
+        files = this.files;
+      }
 
+      const addedFiles = this.addFiles(files);
+      this.args.onDrop?.(addedFiles, this.dataTransferWrapper);
       this.active = false;
       this.dataTransferWrapper = undefined;
     }

--- a/ember-file-upload/src/interfaces.ts
+++ b/ember-file-upload/src/interfaces.ts
@@ -120,6 +120,14 @@ export interface FileDropzoneSignature {
     allowUploadsFromWebsites?: boolean;
 
     /**
+     *
+     * Wether users can drop folders into the dropzone
+     *
+     * @defaulValue false
+     * */
+    allowFolderDrop?: boolean;
+
+    /**
      * This is the type of cursor that should
      * be shown when a drag event happens.
      *

--- a/ember-file-upload/src/system/data-transfer-wrapper.ts
+++ b/ember-file-upload/src/system/data-transfer-wrapper.ts
@@ -43,6 +43,69 @@ export default class DataTransferWrapper {
     return this.files.length ? this.files : this.items;
   }
 
+  async getFilesAndDirectories() {
+    const files: File[] = [];
+
+    const readEntry = async (entry: FileSystemEntry): Promise<File> => {
+      return new Promise((resolve, reject) => {
+        if (entry.isFile) {
+          (entry as FileSystemFileEntry).file((fileEntry: File) => {
+            resolve(fileEntry);
+          });
+        } else {
+          reject('Directory contains nested directories');
+        }
+      });
+    };
+
+    const readAllFilesInDirectory = (item: DataTransferItem): Promise<File[]> =>
+      new Promise((resolve) => {
+        (item.webkitGetAsEntry() as FileSystemDirectoryEntry)
+          ?.createReader()
+          ?.readEntries(async (entries: FileSystemEntry[]) => {
+            const readFiles: File[] = await Promise.all(
+              entries.map(readEntry),
+            ).catch((err) => {
+              throw err;
+            });
+            resolve(readFiles.filter((file) => file !== undefined) as File[]);
+          });
+      });
+
+    const readDataTransferItem = async (
+      item: DataTransferItem,
+    ): Promise<File[]> => {
+      if (item.webkitGetAsEntry()?.isDirectory) {
+        const directoryFile = item.getAsFile() as File;
+        const filesInDirectory: File[] = await readAllFilesInDirectory(item);
+        return [directoryFile, ...filesInDirectory];
+      } else {
+        const fileItem = item.getAsFile() as File;
+        return [fileItem];
+      }
+    };
+
+    if (this.dataTransfer?.items) {
+      const allFilesInDataTransferItems: File[][] = await Promise.all(
+        Array.from(this.dataTransfer?.items).map(readDataTransferItem),
+      );
+
+      const flattenedFileArray: File[] = allFilesInDataTransferItems.reduce(
+        (flattenedList, fileList) => {
+          return [...flattenedList, ...fileList];
+        },
+        [],
+      );
+
+      files.push(...flattenedFileArray);
+    } else {
+      const droppedFiles: File[] = Array.from(this.dataTransfer?.files ?? []);
+      files.push(...droppedFiles);
+    }
+
+    return files;
+  }
+
   get files() {
     return Array.from(this.dataTransfer?.files ?? []);
   }

--- a/ember-file-upload/src/test-support.ts
+++ b/ember-file-upload/src/test-support.ts
@@ -91,6 +91,60 @@ export async function dragAndDrop(
   return triggerEvent(dropzone, 'drop', { dataTransfer });
 }
 
+interface FileSystemEntryStub {
+  isFile: boolean;
+  file: (callback: (file: File | Blob) => void) => void;
+}
+
+export async function dragAndDropDirectory(
+  selector: string,
+  folderName: string,
+  filesInDirectory: (File | Blob)[],
+  ...singleFiles: (File | Blob)[]
+) {
+  const dropzone = find(selector);
+  assert(`Selector '${dropzone}' could not be found.`, dropzone);
+  assert(
+    'All files must be instances of File/Blob type',
+    filesInDirectory.every((file) => file instanceof Blob),
+  );
+
+  const folderItem = {
+    webkitGetAsEntry: () => ({
+      isDirectory: true,
+      createReader: () => ({
+        readEntries: (callback: (entries: FileSystemEntryStub[]) => void) => {
+          const entryFiles = filesInDirectory.map((file) => {
+            return {
+              isFile: true,
+              file: (callback: (file: File | Blob) => void) => {
+                callback(file);
+              },
+            };
+          });
+          callback(entryFiles);
+        },
+      }),
+    }),
+    getAsFile: () => new File([], folderName, { type: '' }),
+  };
+
+  const singleFileItem = (singleFile: File | Blob) => ({
+    webkitGetAsEntry: () => ({
+      isDirectory: false,
+    }),
+    getAsFile: () => singleFile,
+  });
+
+  const dataTransfer = {
+    items: [folderItem, ...singleFiles.map(singleFileItem)],
+  };
+
+  await triggerEvent(dropzone, 'dragenter', { dataTransfer });
+  await triggerEvent(dropzone, 'dragover', { dataTransfer });
+  return triggerEvent(dropzone, 'drop', { dataTransfer });
+}
+
 /**
   Triggers a `dragenter` event on a `FileDropzone` with `files`.
 

--- a/test-app/app/components/demo-upload.gts
+++ b/test-app/app/components/demo-upload.gts
@@ -71,7 +71,7 @@ export default class DemoUpload extends Component<DemoUploadSignature> {
       as |queue|
     }}
       <div class='docs-my-8 text-center'>
-        <FileDropzone @queue={{queue}} class='demo-dropzone' as |dropzone|>
+        <FileDropzone @queue={{queue}} @allowFolderDrop={{true}} class='demo-dropzone' as |dropzone|>
           <div
             class='dropzone-upload-area upload {{if dropzone.active "active"}}'
           >

--- a/test-app/tests/integration/components/file-dropzone-test.gts
+++ b/test-app/tests/integration/components/file-dropzone-test.gts
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, triggerEvent, type TestContext } from '@ember/test-helpers';
 import {
   dragAndDrop,
+  dragAndDropDirectory,
   dragEnter,
   dragLeave,
 } from 'ember-file-upload/test-support';
@@ -177,6 +178,28 @@ module('Integration | Component | FileDropzone', function (hooks) {
     );
 
     assert.verifySteps(['dingus.txt']);
+  });
+
+  test('allowFolderDrop=true allows dropping a directory and reads out the content', async function (this: LocalTestContext, assert) {
+    const queue = this.queue;
+    const onDrop = (files: UploadFile[]) => {
+      files.forEach((file) => assert.step(file.name));
+    };
+
+    await render(<template>
+        <FileDropzone
+          class="test-dropzone"
+          @queue={{queue}}
+          @allowFolderDrop={{true}}
+          @onDrop={{onDrop}} />
+      </template>);
+
+    await dragAndDropDirectory('.test-dropzone', 'directory-name', [
+      new File([], 'dingus.txt'),
+      new File([], 'dingus.png'),
+    ]);
+
+    assert.verifySteps(['directory-name', 'dingus.txt', 'dingus.png']);
   });
 
   // Check for regression of: https://github.com/adopted-ember-addons/ember-file-upload/issues/446

--- a/test-app/tests/unit/system/data-transfer-wrapper-test.js
+++ b/test-app/tests/unit/system/data-transfer-wrapper-test.js
@@ -66,4 +66,37 @@ module('Unit | DataTransferWrapper', function (hooks) {
     };
     assert.strictEqual(this.subject.filesOrItems.length, 2);
   });
+
+  test('directory dropped', async function (assert) {
+    const transfer = {
+      items: [
+        folderItem('directory-name', [
+          new File([], 'fileName.txt'),
+          new File([], 'otherFileName.txt'),
+        ]),
+      ],
+    };
+    this.subject.dataTransfer = transfer;
+    assert.strictEqual((await this.subject.getFilesAndDirectories()).length, 3);
+  });
+
+  const folderItem = (folderName, filesInDirectory) => ({
+    webkitGetAsEntry: () => ({
+      isDirectory: true,
+      createReader: () => ({
+        readEntries: (callback) => {
+          const entryFiles = filesInDirectory.map((file) => {
+            return {
+              isFile: true,
+              file: (callback) => {
+                callback(file);
+              },
+            };
+          });
+          callback(entryFiles);
+        },
+      }),
+    }),
+    getAsFile: () => new File([], folderName, { type: '' }),
+  });
 });

--- a/website/app/components/demo-upload.gjs
+++ b/website/app/components/demo-upload.gjs
@@ -124,6 +124,7 @@ export default class DemoUploadComponent extends Component {
     {{#let (fileQueue name='demo' onFileAdded=this.addToQueue) as |queue|}}
       <FileDropzone
         @queue={{queue}}
+        @allowFolderDrop={{true}}
         class='demo-upload__dropzone'
         as |dropzone|
       >


### PR DESCRIPTION
Recreated https://github.com/adopted-ember-addons/ember-file-upload/pull/834 after updating master with all the latest changes.

As for the question about how in-demand this is: we've needed it for one of our apps and it's been in production for over a year now. I made it so there is an opt-in boolean which needs to be enabled, so by default nothing should change for exisiting users.