### PR TITLE
Remove unnecessary `template-registry.js` export in `rollup.config.mjs`

### DIFF
--- a/ember-file-upload/rollup.config.mjs
+++ b/ember-file-upload/rollup.config.mjs
@@ -24,7 +24,6 @@ export default {
       'index.js',
       'internal.js',
       'test-support.js',
-      'template-registry.js',
     ]),
 
     // These are the modules that should get reexported into the traditional


### PR DESCRIPTION
fix #1067

This is fixing a warning while rollup
```
../ember-file-upload prepare: [js] (!) Generated an empty chunk
../ember-file-upload prepare: [js] "template-registry"
```