### PR TITLE
chore: Service cannot be used before helper failing test

### DIFF
--- a/test-app/tests/integration/helpers/file-queue-helper-test.gts
+++ b/test-app/tests/integration/helpers/file-queue-helper-test.gts
@@ -5,7 +5,7 @@ import { render, click, settled, waitFor } from '@ember/test-helpers';
 import { DEFAULT_QUEUE, FileState } from 'ember-file-upload';
 import type { UploadFile } from 'ember-file-upload';
 import { selectFiles } from 'ember-file-upload/test-support';
-import { uploadHandler } from 'ember-file-upload';
+import { type FileQueueService, uploadHandler } from 'ember-file-upload';
 import { later } from '@ember/runloop';
 import fileQueue from 'ember-file-upload/helpers/file-queue';
 import { on } from '@ember/modifier';
@@ -19,6 +19,31 @@ import {
 module('Integration | Helper | file-queue', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+
+  test('service can be used before helper', async function (assert) {
+    const fileQueueService = this.owner.lookup(
+      'service:file-queue',
+    ) as FileQueueService;
+
+    await render(
+      <template>
+        <ul>
+          {{#each fileQueueService.files as |file|}}
+            <li>
+              {{file.name}}
+            </li>
+          {{/each}}
+        </ul>
+        
+        {{#let (fileQueue) as |queue|}}
+          <label>
+            <input type='file' {{queue.selectFile}} hidden />
+            Select File
+          </label>
+        {{/let}}
+      </template>,
+    );
+  });
 
   test('filter is triggered when selecting files', async function (assert) {
     const filter = (file: File) => {


### PR DESCRIPTION
- When `fileQueue` **service** is used _before_ `(fileQueue)` **helper**, then app fails with:

```
ember.js:626 Uncaught (in promise) Error: Assertion Failed: You attempted to update `_value` on `TrackedStorageImpl`, but it had already been used previously in the same computation.  Attempting to update a value after using it in a computation can cause logical errors, infinite revalidation bugs, and performance issues, and is not supported.

`_value` was first used:

- While rendering:
  -top-level
    application
      index
        (unknown template-only component)
          (result of a `unknown` helper)
            (result of a `unknown` helper)
              (result of a `unknown` helper)
                false.files
```
- This PR is just to document the issue described in #1085

Note that for me to run the test suite locally I had to first apply following patches:
- https://github.com/adopted-ember-addons/ember-file-upload/pull/1084
- https://github.com/adopted-ember-addons/ember-file-upload/pull/1082