### PR TITLE
Widen dependency range for `@ember/test-waiters`

### DIFF
--- a/ember-file-upload/package.json
+++ b/ember-file-upload/package.json
@@ -49,7 +49,7 @@
     "prepare": "pnpm build"
   },
   "dependencies": {
-    "@ember/test-waiters": "^3.0.0",
+    "@ember/test-waiters": "^3.0.0 || ^4.0.0",
     "@embroider/addon-shim": "^1.5.0",
     "@embroider/macros": "^1.0.0",
     "ember-auto-import": "^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
   ember-file-upload:
     dependencies:
       '@ember/test-waiters':
-        specifier: ^3.0.0
+        specifier: ^3.0.0 || ^4.0.0
         version: 3.1.0
       '@embroider/addon-shim':
         specifier: ^1.5.0


### PR DESCRIPTION
Allow existing v3 and new v4. Possibly helps with #1092