### PR TITLE
Cleanup `@ember/service` deprecation

### DIFF
--- a/ember-file-upload/src/components/file-dropzone.ts
+++ b/ember-file-upload/src/components/file-dropzone.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import * as s from '@ember/service';
 import { getOwner } from '@ember/application';
 import DataTransferWrapper from '../system/data-transfer-wrapper.ts';
 import { action } from '@ember/object';
@@ -13,6 +13,8 @@ import {
   FileSource,
 } from '../interfaces.ts';
 import DragListenerModifier from '../system/drag-listener-modifier.ts';
+
+const service = s.service ?? s.inject;
 
 /**
   `FileDropzone` is a component that will allow users to upload files by

--- a/ember-file-upload/src/helpers/file-queue.ts
+++ b/ember-file-upload/src/helpers/file-queue.ts
@@ -1,10 +1,12 @@
 import Helper from '@ember/component/helper';
 import { registerDestructor } from '@ember/destroyable';
-import { inject as service } from '@ember/service';
+import * as s from '@ember/service';
 import type { UploadFile } from '../upload-file.ts';
 import type FileQueueService from '../services/file-queue.ts';
 import { DEFAULT_QUEUE } from '../services/file-queue.ts';
 import type { FileQueueSignature, QueueListener } from '../interfaces.ts';
+
+const service = s.service ?? s.inject;
 
 /**
  * `file-queue` helper is one of the core primitives of ember-file-upload.


### PR DESCRIPTION
In ember v6.3 there was added deprecation for service import from inject https://deprecations.emberjs.com/id/importing-inject-from-ember-service/

This changes allows us to hold support for `ember-source` <= 4.0 ([see changelog](https://github.com/emberjs/ember.js/blob/main/CHANGELOG.md#v410-december-28-2021)) and removes deprecation in newer versions