### PR TITLE
Remove unneeded peer

### DIFF
--- a/ember-file-upload/package.json
+++ b/ember-file-upload/package.json
@@ -51,8 +51,7 @@
   "dependencies": {
     "@ember/test-waiters": "^3.0.0 || ^4.0.0",
     "@embroider/addon-shim": "^1.5.0",
-    "@embroider/macros": "^1.0.0",
-    "ember-auto-import": "^2.0.0"
+    "@embroider/macros": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.1",
@@ -93,7 +92,6 @@
   "peerDependencies": {
     "@ember/test-helpers": "^2.9.3 || ^3.0.3 || ^4.0.4 || ^5.0.0",
     "@glimmer/component": ">=1.1.2",
-    "@glimmer/tracking": "^1.1.2",
     "ember-cli-mirage": "*",
     "ember-modifier": "^3.2.7 || ^4.1.0",
     "miragejs": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       '@embroider/macros':
         specifier: ^1.0.0
         version: 1.16.10(@glint/template@1.5.2)
-      ember-auto-import:
-        specifier: ^2.0.0
-        version: 2.10.0(@glint/template@1.5.2)(webpack@5.97.1)
       ember-cli-mirage:
         specifier: '*'
         version: 3.0.4(@ember/test-helpers@4.0.4(@babel/core@7.26.7)(@glint/template@1.5.2)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1)))(@glint/template@1.5.2)(ember-qunit@8.1.1(@ember/test-helpers@4.0.4(@babel/core@7.26.7)(@glint/template@1.5.2)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1)))(@glint/template@1.5.2)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1))(qunit@2.24.0))(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1))(miragejs@0.1.48)(webpack@5.97.1)
@@ -245,7 +242,7 @@ importers:
         version: 8.1.2(encoding@0.1.13)
       ember-file-upload:
         specifier: workspace:*
-        version: file:ember-file-upload(ztw3jh6hshbtkynz73fbrcyg6y)
+        version: file:ember-file-upload(7pz4mnyuia5qb7ylxvh7tatbsa)
       ember-load-initializers:
         specifier: ^2.1.2
         version: 2.1.2(@babel/core@7.26.7)
@@ -422,7 +419,7 @@ importers:
         version: 8.1.2(encoding@0.1.13)
       ember-file-upload:
         specifier: workspace:*
-        version: file:ember-file-upload(ztw3jh6hshbtkynz73fbrcyg6y)
+        version: file:ember-file-upload(7pz4mnyuia5qb7ylxvh7tatbsa)
       ember-intl:
         specifier: ^7.0.6
         version: 7.1.1(@ember/test-helpers@4.0.4(@babel/core@7.26.7)(@glint/template@1.5.2)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1)))(@glint/template@1.5.2)(typescript@5.6.3)(webpack@5.97.1)
@@ -3446,7 +3443,6 @@ packages:
     peerDependencies:
       '@ember/test-helpers': ^2.9.3 || ^3.0.3 || ^4.0.4 || ^5.0.0
       '@glimmer/component': '>=1.1.2'
-      '@glimmer/tracking': ^1.1.2
       ember-cli-mirage: '*'
       ember-modifier: ^3.2.7 || ^4.1.0
       miragejs: '*'
@@ -11817,15 +11813,13 @@ snapshots:
       - encoding
       - supports-color
 
-  ember-file-upload@file:ember-file-upload(ztw3jh6hshbtkynz73fbrcyg6y):
+  ember-file-upload@file:ember-file-upload(7pz4mnyuia5qb7ylxvh7tatbsa):
     dependencies:
       '@ember/test-helpers': 4.0.4(@babel/core@7.26.7)(@glint/template@1.5.2)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1))
       '@ember/test-waiters': 3.1.0
       '@embroider/addon-shim': 1.9.0
       '@embroider/macros': 1.16.10(@glint/template@1.5.2)
       '@glimmer/component': 1.1.2(@babel/core@7.26.7)
-      '@glimmer/tracking': 1.1.2
-      ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.97.1)
       ember-modifier: 4.2.0(@babel/core@7.26.7)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1))
       tracked-built-ins: 4.0.0(@babel/core@7.26.7)
     optionalDependencies:
@@ -11834,7 +11828,6 @@ snapshots:
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
-      - webpack
 
   ember-get-config@1.1.0(@glint/template@1.5.2):
     dependencies:


### PR DESCRIPTION
@glimmer/tracking removed because it's a real package, but one we don't want to use. This comes up in embroider/vite where the presence of real packages always takes precedence over virtual packages. This is actually problematic because it can break reactivity in subtle ways, even if a dep graph is correct - allowing duplicates of dependencies, which for the glimmer internals, we don't want.

ref https://github.com/ember-cli/ember-addon-blueprint/pull/35

In additional we can remove safely also dependency ember-auto-import... its not necessary for v2 addon