### PR TITLE
Remove reliance on ember-cli-mirage

### DIFF
--- a/ember-file-upload/src/mirage/upload-handler.ts
+++ b/ember-file-upload/src/mirage/upload-handler.ts
@@ -30,12 +30,7 @@ export function uploadHandler(
   fn: (this: void, db: unknown, request: FakeRequest) => void,
   options = { network: null, timeout: null },
 ) {
-  if (
-    macroCondition(
-      dependencySatisfies('miragejs', '*') &&
-        dependencySatisfies('ember-cli-mirage', '*'),
-    )
-  ) {
+  if (macroCondition(dependencySatisfies('miragejs', '*'))) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { Response } = importSync('miragejs') as { Response: any };
     return function (db: unknown, request: FakeRequest) {
@@ -104,8 +99,6 @@ export function uploadHandler(
       });
     };
   } else {
-    throw new Error(
-      'You must add ember-cli-mirage and miragejs to your app to use this helper.',
-    );
+    throw new Error('You must add miragejs to your app to use this helper.');
   }
 }


### PR DESCRIPTION
`ember-cli-mirage` is an optional dependency and not actually required for the `uploadHandler` to function. As shown in the docs, the user will need to set up the Mirage server themselves for this to work at all but that server can be achieved through vanilla `miragejs`, as shown in this issue:  https://github.com/bgantzler/ember-mirage/issues/60

This PR removes the requirement on `ember-cli-mirage`.