### PR TITLE
Add a website test run to the CI matrix

### DIFF
--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -24,3 +24,18 @@ jobs:
 
       - name: Lint
         run: pnpm --filter website lint
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: wyvox/action-setup-pnpm@v3
+        with:
+          node-version: '${{ env.NODE_VERSION }}'
+
+      - name: Test
+        run: pnpm --filter website test:ember --launch chrome


### PR DESCRIPTION
Will help to catch changes which break the docs site.

There aren't meaningful tests, but just building the site would have caught a few past breakages.

Ref: #1149