### PR TITLE
Pin ember-cli-htmlbars to 7.0.1 for ember-source v7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "packageManager": "pnpm@10.33.4",
   "pnpm": {
     "overrides": {
-      "@glimmer/validator": "^0.95.0"
+      "@glimmer/validator": "^0.95.0",
+      "ember-cli-htmlbars": "^7.0.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@glimmer/validator': ^0.95.0
+  ember-cli-htmlbars: ^7.0.1
 
 importers:
 
@@ -31,7 +32,7 @@ importers:
         version: 1.20.2(@babel/core@7.29.0)(@glint/template@1.7.7)
       ember-cli-mirage:
         specifier: '*'
-        version: 3.0.4(@ember-data/model@5.3.13(39715e1ce7624b4e77b13e2b261bdad6))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2)
+        version: 3.0.4(@ember-data/model@5.3.13(wjpk7a62acofdcfgdj7hjibyce))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2)
       miragejs:
         specifier: '*'
         version: 0.1.48
@@ -97,7 +98,7 @@ importers:
         specifier: ^9.2.1
         version: 9.2.1
       ember-cli-htmlbars:
-        specifier: ^7.0.0
+        specifier: ^7.0.1
         version: 7.0.1(@babel/core@7.29.0)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       ember-modifier:
         specifier: ^3.2.7
@@ -140,9 +141,6 @@ importers:
         version: 5.106.2
 
   test-app:
-    dependenciesMeta:
-      ember-file-upload:
-        injected: true
     devDependencies:
       '@babel/core':
         specifier: ^7.29.0
@@ -233,7 +231,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: ^3.0.4
-        version: 3.0.4(@ember-data/model@5.3.13(39715e1ce7624b4e77b13e2b261bdad6))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2)
+        version: 3.0.4(@ember-data/model@5.3.13(wjpk7a62acofdcfgdj7hjibyce))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2)
       ember-cli-sri:
         specifier: ^2.1.1
         version: 2.1.1
@@ -245,7 +243,7 @@ importers:
         version: 5.2.0(@babel/core@7.29.0)(@glint/template@1.7.7)
       ember-file-upload:
         specifier: workspace:*
-        version: file:ember-file-upload(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-mirage@3.0.4(@ember-data/model@5.3.13(39715e1ce7624b4e77b13e2b261bdad6))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2))(ember-modifier@4.3.0(@babel/core@7.29.0))(miragejs@0.1.48)(tracked-built-ins@4.1.2(@babel/core@7.29.0))
+        version: file:ember-file-upload(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-mirage@3.0.4(@ember-data/model@5.3.13(wjpk7a62acofdcfgdj7hjibyce))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2))(ember-modifier@4.3.0(@babel/core@7.29.0))(miragejs@0.1.48)(tracked-built-ins@4.1.2(@babel/core@7.29.0))
       ember-load-initializers:
         specifier: ^3.0.1
         version: 3.0.1(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
@@ -333,11 +331,11 @@ importers:
       webpack:
         specifier: ^5.106.0
         version: 5.106.2
-
-  website:
     dependenciesMeta:
       ember-file-upload:
         injected: true
+
+  website:
     devDependencies:
       '@babel/core':
         specifier: ^7.29.0
@@ -425,7 +423,7 @@ importers:
         version: 5.2.0(@babel/core@7.29.0)(@glint/template@1.7.7)
       ember-file-upload:
         specifier: workspace:*
-        version: file:ember-file-upload(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-mirage@3.0.4(@ember-data/model@5.3.13(39715e1ce7624b4e77b13e2b261bdad6))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2))(ember-modifier@4.3.0(@babel/core@7.29.0))(miragejs@0.1.48)(tracked-built-ins@4.1.2(@babel/core@7.29.0))
+        version: file:ember-file-upload(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-mirage@3.0.4(@ember-data/model@5.3.13(wjpk7a62acofdcfgdj7hjibyce))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2))(ember-modifier@4.3.0(@babel/core@7.29.0))(miragejs@0.1.48)(tracked-built-ins@4.1.2(@babel/core@7.29.0))
       ember-intl:
         specifier: ^8.0.0
         version: 8.2.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))
@@ -507,6 +505,9 @@ importers:
       webpack:
         specifier: ^5.106.0
         version: 5.106.2
+    dependenciesMeta:
+      ember-file-upload:
+        injected: true
 
 packages:
 
@@ -1488,7 +1489,7 @@ packages:
       '@types/ember__controller': ^4.0.2
       '@types/ember__object': ^4.0.4
       '@types/ember__routing': ^4.0.11
-      ember-cli-htmlbars: ^6.0.1
+      ember-cli-htmlbars: ^7.0.1
       ember-modifier: ^3.2.7 || ^4.0.0
     peerDependenciesMeta:
       '@types/ember__array':
@@ -1894,56 +1895,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.130.0':
     resolution: {integrity: sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.130.0':
     resolution: {integrity: sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.130.0':
     resolution: {integrity: sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.130.0':
     resolution: {integrity: sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.130.0':
     resolution: {integrity: sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.130.0':
     resolution: {integrity: sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.130.0':
     resolution: {integrity: sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.130.0':
     resolution: {integrity: sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw==}
@@ -2072,79 +2065,66 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -3628,10 +3608,6 @@ packages:
 
   ember-cli-get-component-path-option@1.0.0:
     resolution: {integrity: sha512-k47TDwcJ2zPideBCZE8sCiShSxQSpebY2BHcX2DdipMmBox5gsfyVrbKJWIHeSTTKyEUgmBIvQkqTOozEziCZA==}
-
-  ember-cli-htmlbars@6.3.0:
-    resolution: {integrity: sha512-N9Y80oZfcfWLsqickMfRd9YByVcTGyhYRnYQ2XVPVrp6jyUyOeRWmEAPh7ERSXpp8Ws4hr/JB9QVQrn/yZa+Ag==}
-    engines: {node: 12.* || 14.* || >= 16}
 
   ember-cli-htmlbars@7.0.1:
     resolution: {integrity: sha512-bNVAwTvBOmk7KjGCN0Vq81w8FAWQ1zXwCS1CUUHTeWdcFypRsv0qUEkTtwxho4H3BYaoqMCXPS45Js9WWtEXYw==}
@@ -8513,7 +8489,7 @@ snapshots:
       debug: 4.4.3
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
       ember-cli-babel: 8.3.1(@babel/core@7.29.0)
-      ember-cli-htmlbars: 6.3.0
+      ember-cli-htmlbars: 7.0.1(@babel/core@7.29.0)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       mdast-util-to-string: 2.0.0
       remark-hbs: 0.4.1
       unist-builder: 2.0.3
@@ -8537,7 +8513,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/graph@5.3.13(0152b41733bbd3a922f0eb455c69c788)':
+  '@ember-data/graph@5.3.13(3wr3kpcxiot4kmcbqzyrmxpvbm)':
     dependencies:
       '@ember-data/store': 5.3.13(@babel/core@7.29.0)(@ember-data/request-utils@5.3.13(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-inflector@5.0.2(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@babel/core@7.29.0)(@ember/test-waiters@4.1.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@babel/core@7.29.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       '@embroider/macros': 1.20.2(@babel/core@7.29.0)(@glint/template@1.7.7)
@@ -8550,9 +8526,9 @@ snapshots:
       - supports-color
     optional: true
 
-  '@ember-data/json-api@5.3.13(6a30dd6b074836f26d7237f428ad5821)':
+  '@ember-data/json-api@5.3.13(qbyadsxubv4hti2eqp5dblplry)':
     dependencies:
-      '@ember-data/graph': 5.3.13(0152b41733bbd3a922f0eb455c69c788)
+      '@ember-data/graph': 5.3.13(3wr3kpcxiot4kmcbqzyrmxpvbm)
       '@ember-data/request-utils': 5.3.13(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-inflector@5.0.2(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       '@ember-data/store': 5.3.13(@babel/core@7.29.0)(@ember-data/request-utils@5.3.13(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-inflector@5.0.2(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@babel/core@7.29.0)(@ember/test-waiters@4.1.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@babel/core@7.29.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       '@embroider/macros': 1.20.2(@babel/core@7.29.0)(@glint/template@1.7.7)
@@ -8566,7 +8542,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@ember-data/legacy-compat@5.3.13(9e252e47562504d837dff77fbf55b96b)':
+  '@ember-data/legacy-compat@5.3.13(tb6eddx22n3bwpochlaiy7lquu)':
     dependencies:
       '@ember-data/request': 5.3.13(@babel/core@7.29.0)(@ember/test-waiters@4.1.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))
       '@ember-data/request-utils': 5.3.13(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-inflector@5.0.2(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
@@ -8577,17 +8553,17 @@ snapshots:
       '@warp-drive/core-types': 0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7)
       ember-source: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
     optionalDependencies:
-      '@ember-data/graph': 5.3.13(0152b41733bbd3a922f0eb455c69c788)
-      '@ember-data/json-api': 5.3.13(6a30dd6b074836f26d7237f428ad5821)
+      '@ember-data/graph': 5.3.13(3wr3kpcxiot4kmcbqzyrmxpvbm)
+      '@ember-data/json-api': 5.3.13(qbyadsxubv4hti2eqp5dblplry)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
     optional: true
 
-  '@ember-data/model@5.3.13(39715e1ce7624b4e77b13e2b261bdad6)':
+  '@ember-data/model@5.3.13(wjpk7a62acofdcfgdj7hjibyce)':
     dependencies:
-      '@ember-data/legacy-compat': 5.3.13(9e252e47562504d837dff77fbf55b96b)
+      '@ember-data/legacy-compat': 5.3.13(tb6eddx22n3bwpochlaiy7lquu)
       '@ember-data/request-utils': 5.3.13(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-inflector@5.0.2(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       '@ember-data/store': 5.3.13(@babel/core@7.29.0)(@ember-data/request-utils@5.3.13(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-inflector@5.0.2(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@babel/core@7.29.0)(@ember/test-waiters@4.1.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@babel/core@7.29.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       '@ember-data/tracking': 5.3.13(@babel/core@7.29.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
@@ -8600,8 +8576,8 @@ snapshots:
       ember-source: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
       inflection: 3.0.2
     optionalDependencies:
-      '@ember-data/graph': 5.3.13(0152b41733bbd3a922f0eb455c69c788)
-      '@ember-data/json-api': 5.3.13(6a30dd6b074836f26d7237f428ad5821)
+      '@ember-data/graph': 5.3.13(3wr3kpcxiot4kmcbqzyrmxpvbm)
+      '@ember-data/json-api': 5.3.13(qbyadsxubv4hti2eqp5dblplry)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -11421,25 +11397,6 @@ snapshots:
 
   ember-cli-get-component-path-option@1.0.0: {}
 
-  ember-cli-htmlbars@6.3.0:
-    dependencies:
-      '@ember/edition-utils': 1.2.0
-      babel-plugin-ember-template-compilation: 2.4.1
-      babel-plugin-htmlbars-inline-precompile: 5.3.1
-      broccoli-debug: 0.6.5
-      broccoli-persistent-filter: 3.1.3
-      broccoli-plugin: 4.0.7
-      ember-cli-version-checker: 5.1.2
-      fs-tree-diff: 2.0.1
-      hash-for-dep: 1.5.2
-      heimdalljs-logger: 0.1.10
-      js-string-escape: 1.0.1
-      semver: 7.7.4
-      silent-error: 1.1.1
-      walk-sync: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
-
   ember-cli-htmlbars@7.0.1(@babel/core@7.29.0)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)):
     dependencies:
       '@babel/core': 7.29.0
@@ -11464,7 +11421,7 @@ snapshots:
 
   ember-cli-is-package-missing@1.0.0: {}
 
-  ember-cli-mirage@3.0.4(@ember-data/model@5.3.13(39715e1ce7624b4e77b13e2b261bdad6))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2):
+  ember-cli-mirage@3.0.4(@ember-data/model@5.3.13(wjpk7a62acofdcfgdj7hjibyce))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2):
     dependencies:
       '@babel/core': 7.29.0
       '@embroider/macros': 1.20.2(@babel/core@7.29.0)(@glint/template@1.7.7)
@@ -11478,7 +11435,7 @@ snapshots:
       ember-source: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
       miragejs: 0.1.48
     optionalDependencies:
-      '@ember-data/model': 5.3.13(39715e1ce7624b4e77b13e2b261bdad6)
+      '@ember-data/model': 5.3.13(wjpk7a62acofdcfgdj7hjibyce)
       '@ember/test-helpers': 5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7)
       ember-qunit: 9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0)
     transitivePeerDependencies:
@@ -11774,7 +11731,7 @@ snapshots:
       content-tag: 4.2.0
       oxc-parser: 0.130.0
 
-  ember-file-upload@file:ember-file-upload(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-mirage@3.0.4(@ember-data/model@5.3.13(39715e1ce7624b4e77b13e2b261bdad6))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2))(ember-modifier@4.3.0(@babel/core@7.29.0))(miragejs@0.1.48)(tracked-built-ins@4.1.2(@babel/core@7.29.0)):
+  ember-file-upload@file:ember-file-upload(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-mirage@3.0.4(@ember-data/model@5.3.13(wjpk7a62acofdcfgdj7hjibyce))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2))(ember-modifier@4.3.0(@babel/core@7.29.0))(miragejs@0.1.48)(tracked-built-ins@4.1.2(@babel/core@7.29.0)):
     dependencies:
       '@ember/test-helpers': 5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7)
       '@ember/test-waiters': 4.1.1(@babel/core@7.29.0)(@glint/template@1.7.7)
@@ -11784,7 +11741,7 @@ snapshots:
       ember-modifier: 4.3.0(@babel/core@7.29.0)
       tracked-built-ins: 4.1.2(@babel/core@7.29.0)
     optionalDependencies:
-      ember-cli-mirage: 3.0.4(@ember-data/model@5.3.13(39715e1ce7624b4e77b13e2b261bdad6))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2)
+      ember-cli-mirage: 3.0.4(@ember-data/model@5.3.13(wjpk7a62acofdcfgdj7hjibyce))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2)
       miragejs: 0.1.48
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
This is due to @glint/environment-ember-loose and @docfy/ember-cli depening on v6 of this package.

We need 7.0.1 which includes a bugfix for ember-source v7

Internal only, basically restores the docs site build under source v7