### PR TITLE
Add recursive folder uploads via drag and drop

### DIFF
--- a/docs/api/class/upload-file.md
+++ b/docs/api/class/upload-file.md
@@ -84,6 +84,7 @@ An object which may be passed as an optional second argument to `upload()` and `
 | `rate`      | Current time in ms it is taking to upload 1 byte.                                                                           | `number` |
 | `state`     | The current state that the file is in.                                                                                      | `string` |
 | `source`    | The source of the file. This is useful for applications that want to gather analytics about how users upload their content. | `string` |
+| `relativePath` | Path of the file within the directory it was added from, including the directory name itself, e.g. `reports/q3/deck.pdf`. Populated for folder drops on a `<FileDropzone @allowFolderDrop={{true}}>` and for files chosen via an input with the `webkitdirectory` attribute. Empty string otherwise. | `string` |
 
 ## Methods
 

--- a/docs/api/component/file-dropzone.md
+++ b/docs/api/component/file-dropzone.md
@@ -40,7 +40,8 @@ import FileDropzone from 'ember-file-upload/components/file-dropzone';
 | -------------------- | ------------------------------------------------------- | --------- | ------------- |
 | `@queue`      | Queue which files will be added to. | `Queue`  |    |
 | `@cursor`      | Type of cursor that should be shown when a drag event happens. Corresponds to [DataTransfer.dropEffect](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/dropEffect). | `string`  | `'copy'`    |
-| `@filter`      | Optionally provide this to validate dropped files before adding them to the queue. | `(file: File, files: File[], index: number) => boolean`  |   |
+| `@allowFolderDrop` | Allow users to drop folders. Dropped directories are traversed recursively and every contained file is added to the queue, with its location exposed via `UploadFile.relativePath`. Hidden files (e.g. `.DS_Store`) are not filtered out – use `@filter` for that. | `boolean` | `false` |
+| `@filter`      | Optionally provide this to validate dropped files before adding them to the queue. `relativePath` is the file's path within a dropped directory, or an empty string. | `(file: File, files: File[], index: number, relativePath: string) => boolean`  |   |
 | `@onDragEnter`      | Called when files have entered the dropzone. | `(files: File[], dataTransfer: DataTransferWrapper) => void`  |   |
 | `@onDragLeave`      | Called when files have left the dropzone. | `(files: File[], dataTransfer: DataTransferWrapper) => void`  |   |
 | `@onDrop`           | Called when file have been dropped on the dropzone. | `(files: UploadFile[], dataTransfer: DataTransferWrapper) => void`  |   |

--- a/docs/file-dropzone.md
+++ b/docs/file-dropzone.md
@@ -29,4 +29,20 @@ This component yields a some useful properties:
 | dropzone.supported  | `Boolean` – If the user's browser supports Drag and Drop |
 | dropzone.active  | `Boolean` – If files are being dragged over the `FileDropzone` |
 
+## Folder drops
+
+Pass `@allowFolderDrop={{true}}` to let users drop folders. Dropped directories are traversed recursively and every contained file is added to the queue.
+
+```hbs
+<FileDropzone @queue={{queue}} @allowFolderDrop={{true}} as |dropzone|>
+  Drag and drop files or folders here to upload them
+</FileDropzone>
+```
+
+Each `UploadFile` exposes `relativePath` – its location within the dropped directory, including the directory name itself, e.g. `reports/q3/deck.pdf`. For files not dropped as part of a directory `relativePath` is an empty string. Use it to recreate the folder structure on your server.
+
+`relativePath` is also populated for files chosen via a folder picker (`<input type="file" webkitdirectory multiple>`), using the browser's native `File.webkitRelativePath`.
+
+Hidden files (e.g. `.DS_Store`) are **not** filtered out. Exclude them, or whole subdirectories, with `@filter` – see [File validation](file-validation.md).
+
 Control which files are added to the queue with [File validation](file-validation.md).

--- a/docs/file-validation.md
+++ b/docs/file-validation.md
@@ -26,6 +26,14 @@ See the example below where the same validation callback is used for both file-s
 
 Commonly validated file properties are `type`, `name` and `size`. For more details see the [MDN File reference](https://developer.mozilla.org/en-US/docs/Web/API/File).
 
+The filter receives four arguments: the `File`, all chosen files, the file's index, and its `relativePath` within a dropped or selected directory (an empty string otherwise). Use `relativePath` to exclude whole subdirectories when [folder drops](file-dropzone.md#folder-drops) are enabled:
+
+```js
+validateFile(file, files, index, relativePath) {
+  return !file.name.startsWith('.') && !relativePath.includes('__MACOSX/');
+}
+```
+
 ```hbs
 {{#let (file-queue name="photos") as |queue|}}
   <FileDropzone

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -47,6 +47,25 @@ module('Acceptance | drag and drop upload notes', function(hooks) {
 });
 ```
 
+To simulate a user dropping folders onto a `<FileDropzone @allowFolderDrop={{true}}>`, use the `dragAndDropDirectory` helper. Directories may be nested arbitrarily deep, and loose files can be dropped alongside them.
+
+```js
+import { dragAndDropDirectory } from 'ember-file-upload/test-support';
+
+await dragAndDropDirectory('.file-dropzone', {
+  directories: [
+    {
+      name: 'reports',
+      files: [new File([], 'summary.pdf')],
+      directories: [{ name: 'q3', files: [new File([], 'deck.pdf')] }],
+    },
+  ],
+  files: [new File([], 'notes.txt')],
+});
+// Files added to the queue have `relativePath` of
+// 'reports/summary.pdf', 'reports/q3/deck.pdf' and '' (for notes.txt)
+```
+
 ## Mirage `upload` handler
 
 A mirage handler is provided which can realistically simulate file uploads, including progress events.

--- a/ember-file-upload/README.md
+++ b/ember-file-upload/README.md
@@ -8,54 +8,6 @@ Uploads can be managed through queues and continue in the background, even after
 
 [View docs](https://ember-file-upload.pages.dev)
 
-## Folder uploads (fork feature)
-
-> This fork adds folder upload support ahead of upstream. See
-> [adopted-ember-addons/ember-file-upload#1066](https://github.com/adopted-ember-addons/ember-file-upload/pull/1066)
-> for the upstream discussion.
-
-Enable folder drops on a dropzone with `@allowFolderDrop`:
-
-```hbs
-<FileDropzone @queue={{queue}} @allowFolderDrop={{true}} as |dropzone|>
-  ...
-</FileDropzone>
-```
-
-Dropped directories are traversed recursively and every contained file is
-added to the queue. Each `UploadFile` exposes `relativePath` — the file's
-location within the dropped directory, including the directory name itself,
-e.g. `reports/q3/deck.pdf`. For files not dropped as part of a directory,
-`relativePath` is an empty string.
-
-`relativePath` is also populated for files selected via a folder picker
-(`<input type="file" webkitdirectory multiple>`), using the browser's native
-`File.webkitRelativePath`.
-
-Hidden files (e.g. `.DS_Store`) are **not** filtered out by the addon —
-exclude them with `@filter` if your application needs to:
-
-```js
-filter = (file) => !file.name.startsWith('.');
-```
-
-In tests, simulate a folder drop with the `dragAndDropDirectory` helper:
-
-```js
-import { dragAndDropDirectory } from 'ember-file-upload/test-support';
-
-await dragAndDropDirectory('.dropzone', {
-  directories: [
-    {
-      name: 'reports',
-      files: [new File([], 'summary.pdf')],
-      directories: [{ name: 'q3', files: [new File([], 'deck.pdf')] }],
-    },
-  ],
-  files: [new File([], 'loose.txt')], // dropped alongside the directory
-});
-```
-
 ## Compatibility
 
 * Ember.js 4.4 or above

--- a/ember-file-upload/README.md
+++ b/ember-file-upload/README.md
@@ -8,6 +8,54 @@ Uploads can be managed through queues and continue in the background, even after
 
 [View docs](https://ember-file-upload.pages.dev)
 
+## Folder uploads (fork feature)
+
+> This fork adds folder upload support ahead of upstream. See
+> [adopted-ember-addons/ember-file-upload#1066](https://github.com/adopted-ember-addons/ember-file-upload/pull/1066)
+> for the upstream discussion.
+
+Enable folder drops on a dropzone with `@allowFolderDrop`:
+
+```hbs
+<FileDropzone @queue={{queue}} @allowFolderDrop={{true}} as |dropzone|>
+  ...
+</FileDropzone>
+```
+
+Dropped directories are traversed recursively and every contained file is
+added to the queue. Each `UploadFile` exposes `relativePath` — the file's
+location within the dropped directory, including the directory name itself,
+e.g. `reports/q3/deck.pdf`. For files not dropped as part of a directory,
+`relativePath` is an empty string.
+
+`relativePath` is also populated for files selected via a folder picker
+(`<input type="file" webkitdirectory multiple>`), using the browser's native
+`File.webkitRelativePath`.
+
+Hidden files (e.g. `.DS_Store`) are **not** filtered out by the addon —
+exclude them with `@filter` if your application needs to:
+
+```js
+filter = (file) => !file.name.startsWith('.');
+```
+
+In tests, simulate a folder drop with the `dragAndDropDirectory` helper:
+
+```js
+import { dragAndDropDirectory } from 'ember-file-upload/test-support';
+
+await dragAndDropDirectory('.dropzone', {
+  directories: [
+    {
+      name: 'reports',
+      files: [new File([], 'summary.pdf')],
+      directories: [{ name: 'q3', files: [new File([], 'deck.pdf')] }],
+    },
+  ],
+  files: [new File([], 'loose.txt')], // dropped alongside the directory
+});
+```
+
 ## Compatibility
 
 * Ember.js 4.4 or above

--- a/ember-file-upload/src/components/file-dropzone.ts
+++ b/ember-file-upload/src/components/file-dropzone.ts
@@ -2,6 +2,8 @@ import Component from '@glimmer/component';
 import * as s from '@ember/service';
 import { getOwner } from '@ember/application';
 import DataTransferWrapper from '../system/data-transfer-wrapper.ts';
+import type { FileWithPath } from '../system/directory-reader.ts';
+import { waitForPromise } from '@ember/test-waiters';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { UploadFile } from '../upload-file.ts';
@@ -136,7 +138,7 @@ export default class FileDropzoneComponent extends Component<FileDropzoneSignatu
   }
 
   @action
-  didDrop(event: FileUploadDragEvent) {
+  async didDrop(event: FileUploadDragEvent) {
     if (this.dataTransferWrapper) {
       this.dataTransferWrapper.dataTransfer = event.dataTransfer;
     }
@@ -221,23 +223,50 @@ export default class FileDropzoneComponent extends Component<FileDropzoneSignatu
     // }
 
     if (this.dataTransferWrapper) {
-      const addedFiles = this.addFiles(this.files);
-      this.args.onDrop?.(addedFiles, this.dataTransferWrapper);
+      const dataTransferWrapper = this.dataTransferWrapper;
 
-      this.active = false;
-      this.dataTransferWrapper = undefined;
+      let files: FileWithPath[] = [];
+      try {
+        // `getFilesWithPaths` must be called synchronously within the drop
+        // event dispatch — browsers neuter `DataTransferItem`s once the
+        // handler yields
+        files = this.args.allowFolderDrop
+          ? await waitForPromise(dataTransferWrapper.getFilesWithPaths())
+          : this.files.map((file) => ({ file, relativePath: '' }));
+      } catch (error) {
+        // Never leave the dropzone in a stuck `active` state
+        console.error('ember-file-upload: error reading dropped files', error);
+      } finally {
+        if (!this.isDestroyed) {
+          this.active = false;
+          this.dataTransferWrapper = undefined;
+        }
+      }
+
+      if (this.isDestroyed) {
+        return;
+      }
+
+      if (!this.multiple) {
+        files = files.slice(0, 1);
+      }
+
+      const addedFiles = this.addFiles(files);
+      this.args.onDrop?.(addedFiles, dataTransferWrapper);
     }
   }
 
-  addFiles(files: File[]) {
+  addFiles(files: FileWithPath[]) {
     const addedFiles = [];
-    for (const file of files) {
+    const rawFiles = files.map(({ file }) => file);
+    for (const [index, { file, relativePath }] of files.entries()) {
       if (file instanceof File) {
-        const uploadFile = new UploadFile(file, FileSource.DragAndDrop);
-        if (
-          this.args.filter &&
-          !this.args.filter(file, files, files.indexOf(file))
-        ) {
+        const uploadFile = new UploadFile(
+          file,
+          FileSource.DragAndDrop,
+          relativePath,
+        );
+        if (this.args.filter && !this.args.filter(file, rawFiles, index)) {
           continue;
         }
         this.queue.add(uploadFile);

--- a/ember-file-upload/src/components/file-dropzone.ts
+++ b/ember-file-upload/src/components/file-dropzone.ts
@@ -266,7 +266,10 @@ export default class FileDropzoneComponent extends Component<FileDropzoneSignatu
           FileSource.DragAndDrop,
           relativePath,
         );
-        if (this.args.filter && !this.args.filter(file, rawFiles, index)) {
+        if (
+          this.args.filter &&
+          !this.args.filter(file, rawFiles, index, relativePath)
+        ) {
           continue;
         }
         this.queue.add(uploadFile);

--- a/ember-file-upload/src/interfaces.ts
+++ b/ember-file-upload/src/interfaces.ts
@@ -23,7 +23,12 @@ export interface SelectFileSignature {
   Args: {
     Positional: [];
     Named: {
-      filter?: (file: File, files: File[], index: number) => boolean;
+      filter?: (
+        file: File,
+        files: File[],
+        index: number,
+        relativePath: string,
+      ) => boolean;
       onFilesSelected?: (files: UploadFile[]) => void;
     };
   };
@@ -154,7 +159,20 @@ export interface FileDropzoneSignature {
     multiple?: boolean;
 
     // actions
-    filter?: (file: File, files: File[], index: number) => boolean;
+    /**
+     * Optionally provide this to validate dropped files before adding them
+     * to the queue.
+     *
+     * `relativePath` is the file's path within a dropped directory (see
+     * `allowFolderDrop`), or an empty string for files not dropped as part
+     * of a directory.
+     */
+    filter?: (
+      file: File,
+      files: File[],
+      index: number,
+      relativePath: string,
+    ) => boolean;
 
     /**
      * Called when files have entered the dropzone.

--- a/ember-file-upload/src/interfaces.ts
+++ b/ember-file-upload/src/interfaces.ts
@@ -120,6 +120,20 @@ export interface FileDropzoneSignature {
     allowUploadsFromWebsites?: boolean;
 
     /**
+     * Whether users can drop folders into the dropzone.
+     *
+     * When enabled, dropped directories are traversed recursively and all
+     * contained files are added to the queue. Each resulting `UploadFile`
+     * exposes its location within the dropped directory via `relativePath`.
+     *
+     * Hidden files (e.g. `.DS_Store`) are not filtered out — use `filter`
+     * if your application needs to exclude them.
+     *
+     * @defaultValue false
+     * */
+    allowFolderDrop?: boolean;
+
+    /**
      * This is the type of cursor that should
      * be shown when a drag event happens.
      *

--- a/ember-file-upload/src/internal.ts
+++ b/ember-file-upload/src/internal.ts
@@ -1,4 +1,5 @@
 import DataTransferWrapper from './system/data-transfer-wrapper.ts';
+import { readDataTransferItems } from './system/directory-reader.ts';
 import HTTPRequest from './system/http-request.ts';
 import UploadFileReader from './system/upload-file-reader.ts';
 import { onloadstart, onprogress, onloadend } from './system/upload.ts';
@@ -11,6 +12,7 @@ import {
 export {
   // Non-public modules imported by the test app
   DataTransferWrapper,
+  readDataTransferItems,
   HTTPRequest,
   UploadFileReader,
   onloadstart,

--- a/ember-file-upload/src/queue.ts
+++ b/ember-file-upload/src/queue.ts
@@ -224,7 +224,13 @@ export class Queue {
         const selectedFiles: UploadFile[] = [];
 
         for (const file of files) {
-          if (filter && !filter?.(file, files, files.indexOf(file))) {
+          // Populated by the browser for inputs with the `webkitdirectory`
+          // attribute, empty otherwise
+          const relativePath = file.webkitRelativePath ?? '';
+          if (
+            filter &&
+            !filter(file, files, files.indexOf(file), relativePath)
+          ) {
             continue;
           }
 

--- a/ember-file-upload/src/system/data-transfer-wrapper.ts
+++ b/ember-file-upload/src/system/data-transfer-wrapper.ts
@@ -1,4 +1,8 @@
 import type { FileUploadDragEvent } from '../interfaces.ts';
+import {
+  readDataTransferItems,
+  type FileWithPath,
+} from './directory-reader.ts';
 
 const getDataSupport = {};
 
@@ -41,6 +45,24 @@ export default class DataTransferWrapper {
 
   get filesOrItems() {
     return this.files.length ? this.files : this.items;
+  }
+
+  /**
+   * Read all dropped files, recursing into dropped directories.
+   *
+   * Must be called synchronously from the `drop` event handler — browsers
+   * neuter `DataTransferItem`s once the handler yields.
+   */
+  getFilesWithPaths(): Promise<FileWithPath[]> {
+    const items = Array.from(this.dataTransfer?.items ?? []);
+
+    if (items.length) {
+      return readDataTransferItems(items);
+    }
+
+    return Promise.resolve(
+      this.files.map((file) => ({ file, relativePath: '' })),
+    );
   }
 
   get files() {

--- a/ember-file-upload/src/system/directory-reader.ts
+++ b/ember-file-upload/src/system/directory-reader.ts
@@ -1,0 +1,132 @@
+// Reads dropped directories via the File and Directory Entries API
+// (`webkitGetAsEntry`). This remains the only cross-browser way to
+// traverse dropped folders — `DataTransferItem.getAsFileSystemHandle()`
+// is Chromium-only.
+// https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry
+
+interface FutureProofDataTransferItem extends DataTransferItem {
+  // May replace `webkitGetAsEntry` in future browsers:
+  // https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry
+  getAsEntry?: () => FileSystemEntry | null;
+}
+
+export interface FileWithPath {
+  file: File;
+
+  /**
+   * Path of the file relative to the dropped directory, including the
+   * directory name itself and the file name — e.g. `reports/q3/deck.pdf`.
+   *
+   * Empty string for files that were not dropped as part of a directory,
+   * mirroring `File.webkitRelativePath` semantics.
+   */
+  relativePath: string;
+}
+
+function getEntry(item: FutureProofDataTransferItem): FileSystemEntry | null {
+  return item.getAsEntry?.() ?? item.webkitGetAsEntry();
+}
+
+function isFileEntry(entry: FileSystemEntry): entry is FileSystemFileEntry {
+  return entry.isFile;
+}
+
+function isDirectoryEntry(
+  entry: FileSystemEntry,
+): entry is FileSystemDirectoryEntry {
+  return entry.isDirectory;
+}
+
+// `fullPath` is absolute from the drop root, e.g. `/folder/sub/file.txt`
+function relativePathFor(entry: FileSystemEntry): string {
+  return entry.fullPath.replace(/^\//, '');
+}
+
+function readFile(entry: FileSystemFileEntry): Promise<File | null> {
+  return new Promise((resolve) => {
+    entry.file(resolve, (error) => {
+      // A single unreadable file should not fail the whole drop
+      console.warn(
+        `ember-file-upload: could not read dropped file ${entry.fullPath}`,
+        error,
+      );
+      resolve(null);
+    });
+  });
+}
+
+function readAllEntries(
+  directory: FileSystemDirectoryEntry,
+): Promise<FileSystemEntry[]> {
+  const reader = directory.createReader();
+  const entries: FileSystemEntry[] = [];
+
+  return new Promise((resolve) => {
+    // Chromium returns at most 100 entries per `readEntries` call, so keep
+    // reading until an empty chunk signals the end of the directory.
+    const readChunk = () => {
+      reader.readEntries(
+        (chunk) => {
+          if (chunk.length > 0) {
+            entries.push(...chunk);
+            readChunk();
+          } else {
+            resolve(entries);
+          }
+        },
+        (error) => {
+          // An unreadable directory should not fail the whole drop
+          console.warn(
+            `ember-file-upload: could not read dropped directory ${directory.fullPath}`,
+            error,
+          );
+          resolve(entries);
+        },
+      );
+    };
+    readChunk();
+  });
+}
+
+async function walkEntry(entry: FileSystemEntry): Promise<FileWithPath[]> {
+  if (isFileEntry(entry)) {
+    const file = await readFile(entry);
+    return file ? [{ file, relativePath: relativePathFor(entry) }] : [];
+  }
+
+  if (isDirectoryEntry(entry)) {
+    const children = await readAllEntries(entry);
+    const nested = await Promise.all(children.map(walkEntry));
+    return nested.flat();
+  }
+
+  return [];
+}
+
+/**
+ * Read all files from dropped `DataTransferItem`s, recursing into
+ * directories.
+ *
+ * Must be called synchronously from the `drop` event handler — browsers
+ * neuter `DataTransferItem`s once the handler yields, so entries and
+ * plain files are captured before this function first awaits.
+ */
+export function readDataTransferItems(
+  items: DataTransferItem[],
+): Promise<FileWithPath[]> {
+  const captured = items.map((item) => ({
+    entry: getEntry(item),
+    file: item.getAsFile(),
+  }));
+
+  return Promise.all(
+    captured.map(async ({ entry, file }): Promise<FileWithPath[]> => {
+      if (entry && isDirectoryEntry(entry)) {
+        return walkEntry(entry);
+      }
+      // Top-level plain file (or non-file item, which `getAsFile`
+      // returns `null` for)
+      return file ? [{ file, relativePath: '' }] : [];
+    }),
+  ).then((nested) => nested.flat());
+}

--- a/ember-file-upload/src/test-support.ts
+++ b/ember-file-upload/src/test-support.ts
@@ -92,6 +92,144 @@ export async function dragAndDrop(
 }
 
 /**
+  A directory to simulate dropping onto a `FileDropzone` with
+  `dragAndDropDirectory`. Directories may be nested arbitrarily deep.
+ */
+export interface DirectoryStub {
+  name: string;
+  files?: File[];
+  directories?: DirectoryStub[];
+}
+
+interface FileSystemEntryStub {
+  isFile: boolean;
+  isDirectory: boolean;
+  name: string;
+  fullPath: string;
+  file?: (
+    successCallback: (file: File) => void,
+    errorCallback?: (error: Error) => void,
+  ) => void;
+  createReader?: () => {
+    readEntries: (
+      successCallback: (entries: FileSystemEntryStub[]) => void,
+      errorCallback?: (error: Error) => void,
+    ) => void;
+  };
+}
+
+// Emulate Chromium's chunked reads (it returns at most 100 entries per
+// `readEntries` call). A small chunk size exercises the chunking loop.
+const READ_ENTRIES_CHUNK_SIZE = 2;
+
+function fileEntryStub(file: File, parentPath: string): FileSystemEntryStub {
+  return {
+    isFile: true,
+    isDirectory: false,
+    name: file.name,
+    fullPath: `${parentPath}/${file.name}`,
+    file: (successCallback) => successCallback(file),
+  };
+}
+
+function directoryEntryStub(
+  directory: DirectoryStub,
+  parentPath: string,
+): FileSystemEntryStub {
+  const fullPath = `${parentPath}/${directory.name}`;
+  const children = [
+    ...(directory.files ?? []).map((file) => fileEntryStub(file, fullPath)),
+    ...(directory.directories ?? []).map((subdirectory) =>
+      directoryEntryStub(subdirectory, fullPath),
+    ),
+  ];
+
+  return {
+    isFile: false,
+    isDirectory: true,
+    name: directory.name,
+    fullPath,
+    createReader: () => {
+      let index = 0;
+      return {
+        readEntries: (successCallback) => {
+          const chunk = children.slice(index, index + READ_ENTRIES_CHUNK_SIZE);
+          index += chunk.length;
+          successCallback(chunk);
+        },
+      };
+    },
+  };
+}
+
+/**
+  Triggers `dragenter`, `dragover`, and `drop` events on a `FileDropzone`
+  with one or more directories, simulating a folder drop.
+
+  Only has an effect when the dropzone has `@allowFolderDrop={{true}}`.
+
+  ```javascript
+    await dragAndDropDirectory('.file-dropzone', {
+      directories: [
+        {
+          name: 'reports',
+          files: [new File([], 'summary.pdf')],
+          directories: [
+            { name: 'q3', files: [new File([], 'deck.pdf')] },
+          ],
+        },
+      ],
+      // loose files dropped alongside the directory
+      files: [new File([], 'notes.txt')],
+    });
+  ```
+
+  Returns `Promise<void>` which resolves when the application is settled.
+
+  @function dragAndDropDirectory
+  @param {string | HTMLElement} target The element or selector representing a FileDropzone
+  @param {Object} options `directories` to drop and optional loose `files`
+  @return {Promise}
+ */
+export async function dragAndDropDirectory(
+  target: string | HTMLElement,
+  options: { directories: DirectoryStub[]; files?: File[] },
+) {
+  const dropzone = target instanceof HTMLElement ? target : find(target);
+
+  assert(`Target '${dropzone}' could not be found.`, dropzone);
+  assert(
+    'options.directories must be an array',
+    options.directories instanceof Array,
+  );
+  assert(
+    'All loose files must be instances of File type',
+    (options.files ?? []).every((file) => file instanceof File),
+  );
+
+  const directoryItems = options.directories.map((directory) => ({
+    kind: 'file',
+    webkitGetAsEntry: () => directoryEntryStub(directory, ''),
+    getAsFile: () => null,
+  }));
+
+  const fileItems = (options.files ?? []).map((file) => ({
+    kind: 'file',
+    webkitGetAsEntry: () => fileEntryStub(file, ''),
+    getAsFile: () => file,
+  }));
+
+  const dataTransfer = {
+    types: ['Files'],
+    items: [...directoryItems, ...fileItems],
+  };
+
+  await triggerEvent(dropzone, 'dragenter', { dataTransfer });
+  await triggerEvent(dropzone, 'dragover', { dataTransfer });
+  return triggerEvent(dropzone, 'drop', { dataTransfer });
+}
+
+/**
   Triggers a `dragenter` event on a `FileDropzone` with `files`.
 
   All `files` must be [HTML5 File objects](https://developer.mozilla.org/en-US/docs/Web/API/File).

--- a/ember-file-upload/src/upload-file.ts
+++ b/ember-file-upload/src/upload-file.ts
@@ -16,12 +16,29 @@ import { estimatedRate } from './system/rate.ts';
 export class UploadFile {
   file: File;
   #source: FileSource;
+  #relativePath?: string;
 
   queue?: Queue;
 
-  constructor(file: File, source: FileSource) {
+  constructor(file: File, source: FileSource, relativePath?: string) {
     this.file = file;
     this.#source = source;
+    this.#relativePath = relativePath;
+  }
+
+  /**
+   * Path of the file relative to the directory it was added from,
+   * including the directory name itself and the file name —
+   * e.g. `reports/q3/deck.pdf`.
+   *
+   * Populated when a directory is dropped on a `FileDropzone` with
+   * `@allowFolderDrop={{true}}`, or when files are selected via an input
+   * with the `webkitdirectory` attribute (via `File.webkitRelativePath`).
+   *
+   * Empty string when the file was not added as part of a directory.
+   */
+  get relativePath(): string {
+    return this.#relativePath || this.file.webkitRelativePath || '';
   }
 
   /**

--- a/test-app/app/components/demo-upload.gts
+++ b/test-app/app/components/demo-upload.gts
@@ -81,7 +81,12 @@ export default class DemoUpload extends Component<DemoUploadSignature> {
       as |queue|
     }}
       <div class="docs-my-8 text-center">
-        <FileDropzone @queue={{queue}} class="demo-dropzone" as |dropzone|>
+        <FileDropzone
+          @queue={{queue}}
+          @allowFolderDrop={{true}}
+          class="demo-dropzone"
+          as |dropzone|
+        >
           <div
             class="dropzone-upload-area upload {{if dropzone.active 'active'}}"
           >

--- a/test-app/tests/integration/components/file-dropzone-test.gts
+++ b/test-app/tests/integration/components/file-dropzone-test.gts
@@ -242,9 +242,14 @@ module('Integration | Component | FileDropzone', function (hooks) {
     ]);
   });
 
-  test('allowFolderDrop=true applies filter to files from directories', async function (this: LocalTestContext, assert) {
+  test('allowFolderDrop=true applies filter to files from directories, passing relative paths', async function (this: LocalTestContext, assert) {
     const queue = this.queue;
-    const filter = (file: File) => !file.name.startsWith('.');
+    const filter = (
+      file: File,
+      _files: File[],
+      _index: number,
+      relativePath: string,
+    ) => !file.name.startsWith('.') && !relativePath.includes('__MACOSX/');
     const onDrop = (files: UploadFile[]) =>
       files.forEach((file) => assert.step(file.relativePath));
 
@@ -265,6 +270,9 @@ module('Integration | Component | FileDropzone', function (hooks) {
         {
           name: 'folder',
           files: [new File([], '.DS_Store'), new File([], 'photo.jpg')],
+          directories: [
+            { name: '__MACOSX', files: [new File([], 'meta.bin')] },
+          ],
         },
       ],
     });

--- a/test-app/tests/integration/components/file-dropzone-test.gts
+++ b/test-app/tests/integration/components/file-dropzone-test.gts
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, triggerEvent, type TestContext } from '@ember/test-helpers';
 import {
   dragAndDrop,
+  dragAndDropDirectory,
   dragEnter,
   dragLeave,
 } from 'ember-file-upload/test-support';
@@ -199,6 +200,163 @@ module('Integration | Component | FileDropzone', function (hooks) {
     );
 
     assert.verifySteps(['dingus.txt']);
+  });
+
+  test('allowFolderDrop=true reads nested directories and reports relative paths', async function (this: LocalTestContext, assert) {
+    const queue = this.queue;
+    const onDrop = (files: UploadFile[]) =>
+      files.forEach((file) => assert.step(file.relativePath || file.name));
+
+    await render(
+      <template>
+        <FileDropzone
+          class="test-dropzone"
+          @queue={{queue}}
+          @allowFolderDrop={{true}}
+          @onDrop={{onDrop}}
+        />
+      </template>,
+    );
+
+    await dragAndDropDirectory('.test-dropzone', {
+      directories: [
+        {
+          name: 'reports',
+          files: [new File([], 'summary.pdf')],
+          directories: [
+            {
+              name: 'q3',
+              files: [new File([], 'deck.pdf'), new File([], 'notes.txt')],
+            },
+          ],
+        },
+      ],
+      files: [new File([], 'loose.txt')],
+    });
+
+    assert.verifySteps([
+      'reports/summary.pdf',
+      'reports/q3/deck.pdf',
+      'reports/q3/notes.txt',
+      'loose.txt',
+    ]);
+  });
+
+  test('allowFolderDrop=true applies filter to files from directories', async function (this: LocalTestContext, assert) {
+    const queue = this.queue;
+    const filter = (file: File) => !file.name.startsWith('.');
+    const onDrop = (files: UploadFile[]) =>
+      files.forEach((file) => assert.step(file.relativePath));
+
+    await render(
+      <template>
+        <FileDropzone
+          class="test-dropzone"
+          @queue={{queue}}
+          @allowFolderDrop={{true}}
+          @filter={{filter}}
+          @onDrop={{onDrop}}
+        />
+      </template>,
+    );
+
+    await dragAndDropDirectory('.test-dropzone', {
+      directories: [
+        {
+          name: 'folder',
+          files: [new File([], '.DS_Store'), new File([], 'photo.jpg')],
+        },
+      ],
+    });
+
+    assert.verifySteps(['folder/photo.jpg']);
+  });
+
+  test('allowFolderDrop=true with multiple=false adds a single file', async function (this: LocalTestContext, assert) {
+    const queue = this.queue;
+    const onDrop = (files: UploadFile[]) =>
+      files.forEach((file) => assert.step(file.relativePath));
+
+    await render(
+      <template>
+        <FileDropzone
+          class="test-dropzone"
+          @queue={{queue}}
+          @allowFolderDrop={{true}}
+          @multiple={{false}}
+          @onDrop={{onDrop}}
+        />
+      </template>,
+    );
+
+    await dragAndDropDirectory('.test-dropzone', {
+      directories: [
+        {
+          name: 'folder',
+          files: [new File([], 'one.txt'), new File([], 'two.txt')],
+        },
+      ],
+    });
+
+    assert.verifySteps(['folder/one.txt']);
+  });
+
+  test('allowFolderDrop=false keeps existing drop behavior', async function (this: LocalTestContext, assert) {
+    const queue = this.queue;
+    const onDrop = (files: UploadFile[]) =>
+      files.forEach((file) => assert.step(`${file.name}:${file.relativePath}`));
+
+    await render(
+      <template>
+        <FileDropzone
+          class="test-dropzone"
+          @queue={{queue}}
+          @onDrop={{onDrop}}
+        />
+      </template>,
+    );
+
+    await dragAndDrop('.test-dropzone', new File([], 'dingus.txt'));
+
+    assert.verifySteps(['dingus.txt:']);
+  });
+
+  test('allowFolderDrop=true resets dropzone state when reading fails', async function (this: LocalTestContext, assert) {
+    const queue = this.queue;
+    const onDrop = (files: UploadFile[]) => assert.step(`drop:${files.length}`);
+
+    await render(
+      <template>
+        <FileDropzone
+          class="test-dropzone"
+          @queue={{queue}}
+          @allowFolderDrop={{true}}
+          @onDrop={{onDrop}}
+          as |dropzone|
+        >
+          <div class="active">{{dropzone.active}}</div>
+        </FileDropzone>
+      </template>,
+    );
+
+    const dataTransfer = {
+      types: ['Files'],
+      items: [
+        {
+          kind: 'file',
+          webkitGetAsEntry: () => {
+            throw new Error('boom');
+          },
+          getAsFile: () => null,
+        },
+      ],
+    };
+
+    await triggerEvent('.test-dropzone', 'dragenter', { dataTransfer });
+    await triggerEvent('.test-dropzone', 'drop', { dataTransfer });
+
+    assert.dom('.active').hasText('false');
+    assert.verifySteps(['drop:0']);
   });
 
   // Check for regression of: https://github.com/adopted-ember-addons/ember-file-upload/issues/446

--- a/test-app/tests/unit/system/directory-reader-test.js
+++ b/test-app/tests/unit/system/directory-reader-test.js
@@ -1,0 +1,185 @@
+import { readDataTransferItems } from 'ember-file-upload/internal';
+import { module, test } from 'qunit';
+
+function fileEntry(file, parentPath, { unreadable = false } = {}) {
+  return {
+    isFile: true,
+    isDirectory: false,
+    name: file.name,
+    fullPath: `${parentPath}/${file.name}`,
+    file: (successCallback, errorCallback) => {
+      if (unreadable) {
+        errorCallback(new Error('read failed'));
+      } else {
+        successCallback(file);
+      }
+    },
+  };
+}
+
+function directoryEntry(name, parentPath, children, { chunkSize = 2 } = {}) {
+  const fullPath = `${parentPath}/${name}`;
+  return {
+    isFile: false,
+    isDirectory: true,
+    name,
+    fullPath,
+    createReader() {
+      const entries = children.map((child) =>
+        typeof child === 'function' ? child(fullPath) : child,
+      );
+      let index = 0;
+      return {
+        readEntries: (successCallback) => {
+          const chunk = entries.slice(index, index + chunkSize);
+          index += chunk.length;
+          successCallback(chunk);
+        },
+      };
+    },
+  };
+}
+
+function directoryItem(entry) {
+  return {
+    kind: 'file',
+    webkitGetAsEntry: () => entry,
+    getAsFile: () => null,
+  };
+}
+
+function fileItem(file) {
+  return {
+    kind: 'file',
+    webkitGetAsEntry: () => fileEntry(file, ''),
+    getAsFile: () => file,
+  };
+}
+
+module('Unit | readDataTransferItems', function () {
+  test('reads a nested directory tree with relative paths', async function (assert) {
+    const root = directoryEntry('reports', '', [
+      (path) => fileEntry(new File([], 'summary.pdf'), path),
+      (path) =>
+        directoryEntry('q3', path, [
+          (subPath) => fileEntry(new File([], 'deck.pdf'), subPath),
+          (subPath) =>
+            directoryEntry('drafts', subPath, [
+              (draftPath) => fileEntry(new File([], 'notes.txt'), draftPath),
+            ]),
+        ]),
+    ]);
+
+    const files = await readDataTransferItems([directoryItem(root)]);
+
+    assert.deepEqual(files.map(({ relativePath }) => relativePath).sort(), [
+      'reports/q3/deck.pdf',
+      'reports/q3/drafts/notes.txt',
+      'reports/summary.pdf',
+    ]);
+  });
+
+  test('reads directories larger than one readEntries chunk', async function (assert) {
+    const manyFiles = Array.from(
+      { length: 7 },
+      (_, index) => new File([], `file-${index}.txt`),
+    );
+    const root = directoryEntry(
+      'big',
+      '',
+      manyFiles.map((file) => (path) => fileEntry(file, path)),
+      { chunkSize: 2 },
+    );
+
+    const files = await readDataTransferItems([directoryItem(root)]);
+
+    assert.strictEqual(files.length, 7);
+  });
+
+  test('handles a mix of directories and loose files', async function (assert) {
+    const root = directoryEntry('folder', '', [
+      (path) => fileEntry(new File([], 'inside.txt'), path),
+    ]);
+
+    const files = await readDataTransferItems([
+      directoryItem(root),
+      fileItem(new File([], 'loose.txt')),
+    ]);
+
+    assert.deepEqual(
+      files.map(({ file, relativePath }) => ({
+        name: file.name,
+        relativePath,
+      })),
+      [
+        { name: 'inside.txt', relativePath: 'folder/inside.txt' },
+        { name: 'loose.txt', relativePath: '' },
+      ],
+    );
+  });
+
+  test('skips unreadable files without failing the drop', async function (assert) {
+    const root = directoryEntry('folder', '', [
+      (path) => fileEntry(new File([], 'good.txt'), path),
+      (path) => fileEntry(new File([], 'bad.txt'), path, { unreadable: true }),
+      (path) => fileEntry(new File([], 'also-good.txt'), path),
+    ]);
+
+    const files = await readDataTransferItems([directoryItem(root)]);
+
+    assert.deepEqual(files.map(({ file }) => file.name).sort(), [
+      'also-good.txt',
+      'good.txt',
+    ]);
+  });
+
+  test('skips unreadable directories without failing the drop', async function (assert) {
+    const root = directoryEntry('folder', '', [
+      (path) => fileEntry(new File([], 'good.txt'), path),
+      (path) => ({
+        isFile: false,
+        isDirectory: true,
+        name: 'locked',
+        fullPath: `${path}/locked`,
+        createReader: () => ({
+          readEntries: (_successCallback, errorCallback) => {
+            errorCallback(new Error('permission denied'));
+          },
+        }),
+      }),
+    ]);
+
+    const files = await readDataTransferItems([directoryItem(root)]);
+
+    assert.deepEqual(
+      files.map(({ file }) => file.name),
+      ['good.txt'],
+    );
+  });
+
+  test('ignores non-file items', async function (assert) {
+    const stringItem = {
+      kind: 'string',
+      webkitGetAsEntry: () => null,
+      getAsFile: () => null,
+    };
+
+    const files = await readDataTransferItems([
+      stringItem,
+      fileItem(new File([], 'file.txt')),
+    ]);
+
+    assert.deepEqual(
+      files.map(({ file }) => file.name),
+      ['file.txt'],
+    );
+  });
+
+  test('returns an empty result for an empty directory', async function (assert) {
+    const root = directoryEntry('empty', '', []);
+
+    const files = await readDataTransferItems([directoryItem(root)]);
+
+    assert.deepEqual(files, []);
+  });
+});

--- a/test-app/tests/unit/upload-file-test.ts
+++ b/test-app/tests/unit/upload-file-test.ts
@@ -12,6 +12,34 @@ module('Unit | UploadFile', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
+  test('relativePath returns the explicit path when provided', function (assert) {
+    const file = new UploadFile(
+      new File([], 'deck.pdf'),
+      FileSource.DragAndDrop,
+      'reports/q3/deck.pdf',
+    );
+
+    assert.strictEqual(file.relativePath, 'reports/q3/deck.pdf');
+  });
+
+  test('relativePath falls back to webkitRelativePath for directory-picker files', function (assert) {
+    const nativeFile = new File([], 'deck.pdf');
+    // `webkitRelativePath` is read-only and can only be set by the browser
+    // for files selected via an input with the `webkitdirectory` attribute
+    Object.defineProperty(nativeFile, 'webkitRelativePath', {
+      value: 'reports/q3/deck.pdf',
+    });
+    const file = new UploadFile(nativeFile, FileSource.Browse);
+
+    assert.strictEqual(file.relativePath, 'reports/q3/deck.pdf');
+  });
+
+  test('relativePath is empty for plain files', function (assert) {
+    const file = new UploadFile(new File([], 'deck.pdf'), FileSource.Browse);
+
+    assert.strictEqual(file.relativePath, '');
+  });
+
   test('it can upload without a `queue`', async function (this: MirageTestContext, assert) {
     this.server.post(
       '/image',

--- a/website/app/components/demo-upload.gjs
+++ b/website/app/components/demo-upload.gjs
@@ -122,6 +122,7 @@ export default class DemoUploadComponent extends Component {
     {{#let (fileQueue name="demo" onFileAdded=this.addToQueue) as |queue|}}
       <FileDropzone
         @queue={{queue}}
+        @allowFolderDrop={{this.uploadOptions.allowFolderDrop}}
         class="demo-upload__dropzone"
         as |dropzone|
       >
@@ -139,7 +140,9 @@ export default class DemoUploadComponent extends Component {
           Estimated time remaining:
           {{this.estimatedTimeRemaining queue}}
         {{else if dropzone.supported}}
-          Or drag and drop files here to upload them
+          Or drag and drop files
+          {{if this.uploadOptions.allowFolderDrop "or folders"}}
+          here to upload them
         {{/if}}
       </FileDropzone>
 
@@ -205,7 +208,7 @@ export default class DemoUploadComponent extends Component {
         <tbody>
           {{#each this.files as |file|}}
             <tr>
-              <td>{{file.name}}</td>
+              <td>{{if file.relativePath file.relativePath file.name}}</td>
               <td>{{file.type}}</td>
               <td>{{localeNumber file.size}} bytes</td>
               <td>{{file.source}}</td>

--- a/website/app/components/options-form.gjs
+++ b/website/app/components/options-form.gjs
@@ -31,6 +31,7 @@ const DEFAULT_HEADERS = {
 
 export const DEFAULT_OPTIONS = {
   type: UPLOAD_TYPES.simulated,
+  allowFolderDrop: false,
   // Simulated
   rate: DEFAULT_RATE,
   // HTTP
@@ -50,6 +51,7 @@ export default class OptionsFormComponent extends Component {
     const entries = Object.fromEntries(formData.entries());
     const uploadOptions = {
       ...entries,
+      allowFolderDrop: entries.allowFolderDrop === 'on',
       rate: parseInt(entries.rate, 10),
       headers: JSON.parse(entries.headers),
     };
@@ -80,6 +82,15 @@ export default class OptionsFormComponent extends Component {
           </div>
         {{/each}}
       </fieldset>
+
+      <label>
+        <input
+          type="checkbox"
+          name="allowFolderDrop"
+          checked={{@uploadOptions.allowFolderDrop}}
+        />
+        Allow folder drops
+      </label>
 
       <label style={{this.toggleVisibility UPLOAD_TYPES.simulated}}>
         Simulated speed:


### PR DESCRIPTION
Adds an opt-in `@allowFolderDrop` argument to `FileDropzone`. When enabled, dropped directories are traversed recursively using the File and Directory Entries API (`webkitGetAsEntry`) — still the only cross-browser way to read dropped folders — and every contained file is added to the queue.

Each `UploadFile` now exposes `relativePath`, the file's location within the dropped directory (e.g. `reports/q3/deck.pdf`). It is also populated for files selected via `<input webkitdirectory>` (including through `queue.selectFile`) using the native `File.webkitRelativePath`.

Implementation notes:

- Entries are captured synchronously in the drop handler since browsers neuter `DataTransferItem`s once the handler yields.
- `readEntries` is called in a loop per directory — Chromium returns at most 100 entries per call.
- Unreadable files or subdirectories are skipped with a warning instead of failing the whole drop, and the dropzone's `active` state always resets via try/finally.
- Traversal is wrapped in `waitForPromise` so `settled()` waits for it in tests.
- `@filter` (and the `filter=` option of `queue.selectFile`) now receives the file's `relativePath` as a fourth argument, so whole subdirectories such as `__MACOSX/` can be excluded. Existing three-argument filters are unaffected.
- New `dragAndDropDirectory` test helper simulates nested folder drops.

Hidden files (e.g. `.DS_Store`) are intentionally not filtered; apps can exclude them by name or by `relativePath` with `@filter`.

Docs are updated (FileDropzone API, `UploadFile.relativePath`, file validation, testing helper), and the docsite demo has an "Allow folder drops" toggle for trying it in a real browser.

Based on the discussion in
https://github.com/adopted-ember-addons/ember-file-upload/pull/1066, extended with recursion and relative paths.
